### PR TITLE
Improved regular reviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       env:
         # See https://github.com/mszostok/codeowners-validator/blob/main/docs/gh-auth.md#public-repositories
         # And https://github.com/mszostok/codeowners-validator/pull/222#issuecomment-2079521185
+        # The same App is also used in ./review.yml
         GITHUB_APP_ID: ${{ secrets.APP_ID }}
         GITHUB_APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
         GITHUB_APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,11 +17,18 @@ jobs:
         with:
           path: repo
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # This GitHub App needs Organization/Members/read-only access
+          # to figure out who's part of the team
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Generate issue body
         run: repo/scripts/review-body.sh repo ${{ github.repository }} > body
         env:
-          # This token has read-only admin access to see who has write access to this repo
-          GH_TOKEN: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - run: |
           gh api \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ Thus, all organisational changes tracked in this repository should be proposed w
 and the changes should only to be implemented when the PR is merged.
 This may be done manually (e.g. by the person merging the PR) or automatically (e.g. using CD).
 
-All files should have at least somebody in charge of keeping it up-to-date, which should be described with an entry in [CODEOWNERS](./.github/CODEOWNERS). Those people will be requested for a review and be given write access to the repository, see also [permissions of this repository](./doc/org-repo.md).
+All files should have at least somebody in charge of keeping it up-to-date, which should be described with an entry in [CODEOWNERS](./.github/CODEOWNERS).
+Those people will be requested for a review and be given write access to the repository, see also [permissions of this repository](./doc/org-repo.md).
 
 ## Regular manual reviews
 
 Unavoidibly it can also happen for reality to deviate from the documentation without a PR.
-To mitigate this, all people with [code owner entries](./.github/CODEOWNERS) must regularly review their files.
+To mitigate this, all people with [code owner entries](./.github/CODEOWNERS) for files in the `doc` directory must regularly review their files.
 This is done by [automatically opening an issue every month](./.github/workflows/review.yml) to ping all code owners.
 
 This serves as an initial fallback, but more automatic approaches could be implemented in the future, e.g. by scraping and comparing the state.

--- a/scripts/review-body.sh
+++ b/scripts/review-body.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 # This script outputs the contents of the regular review issue, see ./github/workflows/review.yml
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
 if (( $# != 2 )); then
   echo "Usage: $0 PATH OWNER/REPO"
   exit 1
@@ -75,10 +73,3 @@ listDir() {
 }
 
 listDir "" ""
-
-echo ""
-
-# Check that all code owners have write permissions
-# `|| true` because this script fails when there are code owners without permissions,
-# which is useful to fail PRs, but not here
-bash "$SCRIPT_DIR"/unprivileged-owners.sh "$root" "$repo" || true

--- a/scripts/review-body.sh
+++ b/scripts/review-body.sh
@@ -72,4 +72,4 @@ listDir() {
   done
 }
 
-listDir "" ""
+listDir "" "doc"


### PR DESCRIPTION
This improves the regular monthly reviews (such as [this one](https://github.com/NixOS/org/issues/13)) by:
- Only listing files in the [`doc` directory](https://github.com/NixOS/org/tree/23ca634fca1a570f52e5499899fb5dd5de41c491/doc)
- Expand teams to their users, such that notifications are sent (might be a GitHub bug, see https://github.com/orgs/community/discussions/39049)

I already tested this in a [separate repo](https://github.com/Infinisil-s-Test-Organization/some-test/tree/51108948095b781666198ef42e9e7e141943b28a): https://github.com/Infinisil-s-Test-Organization/some-test/issues/8

@zimbatm To make this work, the GitHub app (https://github.com/NixOS/org/settings/installations) needs extra permissions, specifically the "Organization/Members/read-only" permission. Once you added the extra permission, you'll have to go to the installation and confirm the new permission.

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: