### PR TITLE
Remove myself from interim org owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /doc/org-repo.md @NixOS/org
 /doc/discourse.md @NixOS/org
-/doc/github.md @domenkozar @edolstra @garbas @zimbatm @infinisil @lassulus
+/doc/github.md @domenkozar @edolstra @garbas @zimbatm @lassulus
 /doc/matrix.md @NixOS/org
 /doc/moderation.md @NixOS/org
 /doc/nixos-releases.md @NixOS/org

--- a/doc/github.md
+++ b/doc/github.md
@@ -9,7 +9,6 @@ A very small number of people are owners of this GitHub Organisation, and have u
 - [@zimbatm](https://github.com/zimbatm)
 
 Furthermore, there are some interim owners to help out:
-- [@infinisil](https://github.com/infinisil)
 - [@lassulus](https://github.com/lassulus)
 
 These interim owners are responsible for receiving requests to change anything about the GitHub organisation in the [GitHub Requests Matrix room](https://matrix.to/#/#org_owners:nixos.org), and either acting upon them or forwarding them to the right person.


### PR DESCRIPTION
Follow-up to #18

Slight change of plans: I'd rather not get distracted by more responsibilities, instead I'll focus on the work for the NCA.

Ping @Lassulus for merging this and removing me as an org owner again