### PR TITLE
Update org owners, define authority and responsibilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,8 @@
 
 /doc/org-repo.md @NixOS/steering
 /doc/discourse.md @NixOS/steering
-/doc/github.md @NixOS/steering
+/doc/github.md @NixOS/org
+/doc/github-org-owners.md @NixOS/steering
 /doc/matrix.md @NixOS/steering
 /doc/moderation.md @NixOS/steering
 /doc/nixos-releases.md @NixOS/steering

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For contributing see [here](./CONTRIBUTING.md).
 - [Org repo](./doc/org-repo.md)
 - [Discourse](./doc/discourse.md)
 - [GitHub](./doc/github.md)
+  - [Org owners](./doc/github-org-owners.md)
 - [Matrix](./doc/matrix.md)
 - [Moderation](./doc/moderation.md)
 - [NixOS releases](./doc/nixos-releases.md)

--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -1,0 +1,50 @@
+## GitHub org owners
+
+The following people have the GitHub "owners" permissions on the NixOS organization:
+<!-- Also keep this in sync with the members of @NixOS/org! -->
+- [@infinisil](https://github.com/infinisil)
+- [@lassulus](https://github.com/lassulus)
+- [@tomberek](https://github.com/tomberek)
+- [@winterqt](https://github.com/winterqt)
+- [@zimbatm](https://github.com/zimbatm)
+## How to contact the team
+For any GitHub-related needs, you can reach out to the org owners by either:
+- Pinging [@NixOS/org](https://github.com/orgs/NixOS/teams/org)
+- [Creating an issue in this repository](https://github.com/NixOS/org/issues/new).
+- Messaging in the [Github org owners help desk Matrix room](https://matrix.to/#/#org_owners:nixos.org).
+
+### Authority and processes
+This team's role is to manage and unblock users of the github.com/NixOS GitHub organization. The @NixOS/steering gives them autonomy to handle small day-to-day tasks and expects them to escalate bigger decisions.
+
+All org owners can individually take care of implementing:
+- Decisions by bodies that have the authority to make GitHub org changes such as:
+  - Arbitrary decisions by the Steering Committee.
+  - Moderation decisions by the moderation team.
+  - Changes from approved RFCs.
+- Low-impact changes, such as:
+  - Adding new org members to allow review requests.
+  - Creating new unprivileged Nixpkgs teams for mention.
+  - Updating repository meta information.
+
+Org owners need approval from at least one other org owner to take care of implementing
+higher-impact changes that are _not controversial_, such as:
+- Administer unmaintained repos, such as:
+  - Performing maintenance.
+  - Giving commit access to trusted people that offer maintenance.
+  - Archiving if appropriate.
+- Create GitHub apps to unblock automation.
+- Changes to the structure and CI of the [org repository](https://github.com/NixOS/org).
+- Content updates to the [GitHub organisation documentation](./github.md).
+
+Org owners have no authority to make other changes.
+
+### Responsibilities
+
+- Receive and process requests.
+  - We expect org owners to be subscribed to the NixOS/org repo.
+  - Each request should land in at least 2 org owners inboxes of some kind.
+- Ensure that all non-trivial and non-sensitive org owner actions are
+  publicly logged in either of the above channels.
+- Escalate requests outside the given authority to the Steering Committee.
+- Maintain the [GitHub organisation documentation](./github.md).
+- Act as janitor for this repository.

--- a/doc/github.md
+++ b/doc/github.md
@@ -2,17 +2,7 @@
 
 The [NixOS GitHub organisation](https://github.com/nixos) and all its repositories is part of the [official resources](./resources.md).
 
-A very small number of people are owners of this GitHub Organisation, and have ultimate permissions over it:
-- [@domenkozar](https://github.com/domenkozar)
-- [@edolstra](https://github.com/edolstra)
-- [@garbas](https://github.com/garbas)
-- [@zimbatm](https://github.com/zimbatm)
-
-Furthermore, there is an interim owner to help out:
-- [@lassulus](https://github.com/lassulus)
-
-This interim owner is responsible for receiving requests to change anything about the GitHub organisation in the [Github org owners help desk Matrix room](https://matrix.to/#/#org_owners:nixos.org), and either acting upon them or forwarding them to the right person.
-
+The org owners documentation is [here](./github-org-owners.md).
 
 ## Repositories
 


### PR DESCRIPTION
After discussions with the Steering Committee to set the general direction for this, here's a hashed-out proposal by me to update org owners and define their authority and responsibilities. 

Needs to be approved by @NixOS/steering before it can be merged. Note that the convention for this repo is that the person merging also implements the changes.

Also note that the first commit is shared with #36.