### PR TITLE
Document official Google calendar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,4 @@
 /doc/values.md @NixOS/steering
 /doc/constitution.md @NixOS/steering
 /doc/nixpkgs-committers.md @Mic92 @NickCao @jtojnar
+/doc/calendar.md @edolstra @tomberek

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ For contributing see [here](./CONTRIBUTING.md).
 - [Governance](./doc/governance.md)
   - [Nix Governance Constitution](./doc/constitution.md)
   - [Nix Community Values](./doc/values.md)
+- [Calendar](./doc/calendar.md)

--- a/doc/calendar.md
+++ b/doc/calendar.md
@@ -1,0 +1,13 @@
+# Calendar
+
+There is [this official Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com) ([ics](https://calendar.google.com/calendar/ical/b9o52fobqjak8oq8lfkhg3t0qg%40group.calendar.google.com/public/basic.ics)).
+
+These Google accounts have access to manage permissions (and make changes to events):
+<!-- Keep this list in sync with the codeowners of this file! -->
+- edolstra@gmail.com (@edolstra)
+- tomberek@gmail.com (@tomberek)
+
+These Google accounts can only make changes to events:
+- valentin.gagarin@moduscreate.com (@fricklerhandwerk)
+- silvan.mosberger@moduscreate.com (@infinisil)
+- nixpkgs-architecture@infinisil.com (@infinisil)


### PR DESCRIPTION
Let's document the permissions for the official Google calendar explicitly, so that people can make PRs to request changes to it. I asked @edolstra for the current permissions, which this PR is based on.

@edolstra @grahamc <s>@rbvermaa</s> @garbas @tomberek As the only people with access to manage permissions, you're being added as a code owner. The expectations are:
- You review and merge PRs proposing changes to it.
- The person merging also implements the change afterwards.
- No changes should be done without a PR.

This effectively makes this documentation the source of truth for calendar permissions. If you're okay with doing this, please approve this PR.

I'd say that those who don't react to this PR until 2024-12-23 (next Monday) can be assumed to not need access to manage permissions anymore, and would ask the others to remove them before we merge this PR. This ensures that everybody is willing to actively help maintain it.