### PR TITLE
Fix link verification CI

### DIFF
--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -11,7 +11,7 @@ The following people have the GitHub "owners" permissions on the NixOS organizat
 For any GitHub-related needs, you can reach out to the org owners by either:
 - Pinging [@NixOS/org](https://github.com/orgs/NixOS/teams/org)
 - [Creating an issue in this repository](https://github.com/NixOS/org/issues/new).
-- Messaging in the [Github org owners help desk Matrix room](https://matrix.to/#/#org_owners:nixos.org).
+- Messaging in the [Github org owners help desk Matrix room](https://matrix.to/#/%23org_owners:nixos.org).
 
 ### Authority and processes
 This team's role is to manage and unblock users of the github.com/NixOS GitHub organization. The @NixOS/steering gives them autonomy to handle small day-to-day tasks and expects them to escalate bigger decisions.

--- a/doc/github.md
+++ b/doc/github.md
@@ -50,7 +50,7 @@ The [RFC Steering Committee](https://nixos.org/community/teams/rfc-steering-comm
 
 Infrastructure configuration.
 
-The [infrastructure team](https://nixos.org/community/teams/infrastructure) controls this repository.
+The [infrastructure team](https://nixos.org/community/teams/infrastructure/) controls this repository.
 
 ### [foundation](https://github.com/NixOS/foundation)
 

--- a/doc/matrix.md
+++ b/doc/matrix.md
@@ -1,6 +1,6 @@
 # Matrix
 
-The [`nixos.org` Matrix server](https://matrix.to/#/#space:nixos.org) is the official chat platform.
+The [`nixos.org` Matrix server](https://matrix.to/#/%23space:nixos.org) is the official chat platform.
 
-If you'd like a new room for a certain topic, you can discuss this is the [NixOS Matrix Discussion](https://matrix.to/#/#matrix-discussion:nixos.org) room.
-Once decided, you can make the request in the [NixOS Matrix Suggestions](https://matrix.to/#/#matrix-suggestions:nixos.org) room.
+If you'd like a new room for a certain topic, you can discuss this is the [NixOS Matrix Discussion](https://matrix.to/#/%23matrix-discussion:nixos.org) room.
+Once decided, you can make the request in the [NixOS Matrix Suggestions](https://matrix.to/#/%23matrix-suggestions:nixos.org) room.

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -17,7 +17,7 @@ This domain also hosts various other websites and services, such as:
 - Mail server
 - [Matrix](./matrix.md)
 - [Discourse](./discourse.md)
-- [Wiki](https://wiki.nixos.org)
+- [Wiki](https://wiki.nixos.org/wiki/NixOS_Wiki)
 - [Search](https://search.nixos.org/)
 - [Status page](https://status.nixos.org/)
 - [Hydra](https://hydra.nixos.org/)
@@ -27,7 +27,7 @@ This domain also hosts various other websites and services, such as:
 A secondary domain is `nix.dev`, which hosts [the main documentation](https://nix.dev/) ([source](https://github.com/NixOS/nix.dev)).
 
 See the [infra repository](https://github.com/nixos/infra) for more information.
-To request permissions or changes to the infrastructure, get in touch with the [infrastructure team](https://nixos.org/community/teams/infrastructure).
+To request permissions or changes to the infrastructure, get in touch with the [infrastructure team](https://nixos.org/community/teams/infrastructure/).
 
 ## GitHub
 


### PR DESCRIPTION
CI verifies correctness of links, but there's some [new recent failures](https://github.com/NixOS/org/actions/runs/12620179704/job/35165597446?pr=46), including:
- New redirects
- Stricter verification against RFC3986, which matrix.to links tend to violate: https://github.com/matrix-org/matrix.to/issues/251