### PR TITLE
Expand org owner authority

### DIFF
--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -29,10 +29,9 @@ All org owners can individually take care of implementing:
 
 Org owners need approval from at least one other org owner to take care of implementing
 higher-impact changes that are _not controversial_, such as:
-- Administer unmaintained repos, such as:
-  - Performing maintenance.
-  - Giving commit access to trusted people that offer maintenance.
-  - Archiving if appropriate.
+- Changes to permissions of teams and people
+- Maintenance on otherwise unmaintained repositories
+- Archival or deletion of resources that aren't needed anymore
 - Changes necessary to unblock automation.
 - Changes to the structure and CI of the [org repository](https://github.com/NixOS/org).
 - Content updates to the [GitHub organisation documentation](./github.md).


### PR DESCRIPTION
I'd like to be able to remove the security and systemd team's explicit Nixpkgs write access, which seems to be a historical artifact from needing to have write access to be requested for reviews with CODEOWNERS.

The current authority doesn't allow for that, so this PR is expanding it to include that and similar changes. Notably the expansion is conditioned under non-controversial changes, and needing approval from two org owners.