### PR TITLE
Clarify and extend org owner authority

### DIFF
--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -18,29 +18,27 @@ For any GitHub-related needs, you can reach out to the org owners by either:
 This team's role is to manage and unblock users of the NixOS GitHub organization.
 The [Steering Committee (SC)](./governance.md) gives them autonomy to handle
 small day-to-day tasks and expects them to escalate bigger decisions.
+The following decision tree describes the org owners authority:
 
-All org owners can individually take care of implementing:
-- Decisions by bodies that have the authority to make GitHub org changes such as:
+**Is the change impactful or controversial?**
+- *Yes*: **Is the change pre-approved by a body with corresponding authority?** This includes:
   - Arbitrary decisions by the Steering Committee.
   - Moderation decisions by the moderation team.
   - Changes from approved RFCs.
-- Low-impact changes, such as:
+
+  *Yes*: Any single org owner can implement it.
+
+  *No*: Not within the org owners authority, should be escalated to the SC.
+
+- *No*: **Is the change one of the following?**
   - Adding new org members to allow review requests.
   - Creating new unprivileged Nixpkgs teams for mention.
   - Updating repository meta information.
-- Changes requested by a repository admin that have no impact outside their repository.
+  - Changes requested by a repository admin that have no impact outside their repository.
 
-Org owners need approval from at least one other org owner to take care of implementing
-higher-impact changes that are _not controversial_, such as:
-- Administer unmaintained repos, such as:
-  - Performing maintenance.
-  - Giving commit access to trusted people that offer maintenance.
-  - Archiving if appropriate.
-- Changes necessary to unblock automation.
-- Changes to the structure and CI of the [org repository](https://github.com/NixOS/org).
-- Content updates to the [GitHub organisation documentation](./github.md).
+  *Yes*: Any single org owner can implement it.
 
-Org owners have no authority to make other changes.
+  *No*: Approval from at least one other org owner is needed to implement it.
 
 ### Responsibilities
 

--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -1,12 +1,13 @@
 ## GitHub org owners
 
-The following people have the GitHub "owners" permissions on the NixOS organization:
+The following people have the GitHub "owners" permissions on the [NixOS organization](https://github.com/nixos):
 <!-- Also keep this in sync with the members of @NixOS/org! -->
 - [@infinisil](https://github.com/infinisil)
 - [@lassulus](https://github.com/lassulus)
 - [@tomberek](https://github.com/tomberek)
 - [@winterqt](https://github.com/winterqt)
 - [@zimbatm](https://github.com/zimbatm)
+
 ## How to contact the team
 For any GitHub-related needs, you can reach out to the org owners by either:
 - Pinging [@NixOS/org](https://github.com/orgs/NixOS/teams/org)
@@ -14,7 +15,9 @@ For any GitHub-related needs, you can reach out to the org owners by either:
 - Messaging in the [Github org owners help desk Matrix room](https://matrix.to/#/%23org_owners:nixos.org).
 
 ### Authority and processes
-This team's role is to manage and unblock users of the github.com/NixOS GitHub organization. The @NixOS/steering gives them autonomy to handle small day-to-day tasks and expects them to escalate bigger decisions.
+This team's role is to manage and unblock users of the NixOS GitHub organization.
+The [Steering Committee (SC)](./governance.md) gives them autonomy to handle
+small day-to-day tasks and expects them to escalate bigger decisions.
 
 All org owners can individually take care of implementing:
 - Decisions by bodies that have the authority to make GitHub org changes such as:


### PR DESCRIPTION
I've been annoying the other org members with my complaints when we didn't follow the authority to the dot :sweat_smile:

This was because:
- The "such as" wording left it open to ambiguity as to whether it's only the listed items or also others (while proper English would imply the latter, I meant the former when I wrote this originally)
- The former interpretation is unnecessarily restrictive, requiring further requests to increase authority whenever something new was being done.

This PR makes it very explicit that it's an exclusive list for individually-implementable changes (certain pre-approved changes and minimal-impact changes), while leaving _all_ other non-controversial and non-impactful changes up to the org owners, given two approvals.

This should hopefully require less changes to this document in the future.