### PR TITLE
update CODEOWNERS to match calendar owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,4 +24,4 @@
 /doc/values.md @NixOS/steering
 /doc/constitution.md @NixOS/steering
 /doc/nixpkgs-committers.md @Mic92 @NickCao @jtojnar
-/doc/calendar.md @edolstra @tomberek
+/doc/calendar.md @edolstra @tomberek @fricklerhandwerk


### PR DESCRIPTION
follow-up on https://github.com/NixOS/org/pull/59#discussion_r1925627906 (thanks @infinisil for the attention to detail)