### PR TITLE
Make the org team code owners of code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /LICENSE @NixOS/org
 
 /.gitignore @NixOS/org
-/.github/CODEOWNERS @NixOS/steering
+/.github/CODEOWNERS @NixOS/org
 /.github/workflows @NixOS/org
 /scripts @NixOS/org
 /npins @NixOS/org


### PR DESCRIPTION
The SC should not be requested for review when not necessary. Code owner updates are rarely relevant for the SC and can be dealt with by the org owners/janitors.