### PR TITLE
Enable SC group messages on Discourse

### DIFF
--- a/doc/governance.md
+++ b/doc/governance.md
@@ -13,7 +13,9 @@ The current SC consists of these members:
 - [@tomberek](https://github.com/tomberek) (term ends 2025)
 - [@winterqt](https://github.com/winterqt) (term ends 2025)
 
-The entire SC can be reached via <steering@nixos.org> or by pinging the [@NixOS/steering](https://github.com/orgs/nixos/teams/steering) GitHub team.
+The entire SC can be reached via <steering@nixos.org>,
+messaging the [SC's Discourse group](https://discourse.nixos.org/g/steering_committee)
+or by pinging the [@NixOS/steering](https://github.com/orgs/nixos/teams/steering) GitHub team.
 
 ## RFC Process
 


### PR DESCRIPTION
Doesn't work right now, needs to be implemented before merged, probably by @jtojnar as the SC-representative Discourse admin.

This was [discussed before](https://github.com/NixOS/org/pull/58#discussion_r1924177806).