### PR TITLE
NixCon is official, 2025 organisation and location (OST in Rapperswil-Jona, Switzerland)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,4 @@
 /doc/constitution.md @NixOS/steering
 /doc/nixpkgs-committers.md @Mic92 @NickCao @jtojnar
 /doc/calendar.md @edolstra @tomberek @fricklerhandwerk
+/doc/nixcon.md @NixOS/steering

--- a/doc/github-org-owners.md
+++ b/doc/github-org-owners.md
@@ -1,6 +1,8 @@
 ## GitHub org owners
 
-The following people have the GitHub "owners" permissions on the NixOS organization:
+Both the [NixOS](https://github.com/nixos) and [NixCon](https://github.com/nixcon) GitHub organisations are official.
+
+The following people have the GitHub "owners" permissions:
 <!-- Also keep this in sync with the members of @NixOS/org! -->
 - [@infinisil](https://github.com/infinisil)
 - [@lassulus](https://github.com/lassulus)

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -1,0 +1,14 @@
+# NixCon
+
+NixCon is a yearly official Nix conference by and for the community.
+The legal and fiscal backing is provided by the NixOS Foundation.
+The conference has previously been held in these locations:
+
+- 2015: Berlin (Germany), http://2015.nixcon.org/
+- 2017: Unterföhring (Germany) http://nixcon2017.org/
+- 2018: London (UK), https://2018.nixcon.org/
+- 2019: Brno (Czech Republic), http://2019.nixcon.org/
+- 2020: (online), http://2020.nixcon.org/
+- 2022: Paris (France), https://2022.nixcon.org/
+- 2023: Darmstadt (Germany), https://2023.nixcon.org/
+- 2024: Berlin (Germany), https://2024.nixcon.org/

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -12,3 +12,31 @@ The conference has previously been held in these locations:
 - 2022: Paris (France), https://2022.nixcon.org/
 - 2023: Darmstadt (Germany), https://2023.nixcon.org/
 - 2024: Berlin (Germany), https://2024.nixcon.org/
+
+## NixCon 2025: Rapperswil-Jona (Switzerland)
+
+NixCon 2025 is planned to be held at [OST Rapperswil-Jona SG, Switzerland](https://github.com/nixcon/nixcon-proposals/issues/4) ([Map](https://www.openstreetmap.org/way/34754484)).
+
+These are the organisers (ordered alphabetically):
+- Alex (Github: [@ners](https://github.com/ners), [Matrix](https://matrix.to/#/%40ners:nixos.dev), [Discourse](https://discourse.nixos.org/u/ners))
+- Andreas (Github: [@Nebucatnetzer](https://github.com/Nebucatnetzer), [Matrix](https://matrix.to/#/%40nebucatnetzer13:matrix.org), [Discourse](https://discourse.nixos.org/u/Nebucatnetzer))
+- Andreas (GitHub: [@andir](https://github.com/andir), [Matrix](https://matrix.to/#/%40andi:kack.it), [Discourse](https://discourse.nixos.org/u/andir))
+- Berber (Github: [@zmberber](https://github.com/zmberber), [Matrix](@andi:kack.itzmberber:matrix.org), [Discourse](andirzmberber))
+- John (Github: [@john-rodewald](https://github.com/john-rodewald), [Matrix](https://matrix.to/#/%40john-rodewald:nixos.dev), [Discourse](https://discourse.nixos.org/u/john-rodewald))
+- Kenji (Github: [@a-kenji](https://github.com/a-kenji), [Matrix](https://matrix.to/#/%40a-kenji:matrix.org), [Discourse](https://discourse.nixos.org/u/a-kenji))
+- Lassulus (Github: [@lassulus](https://github.com/lassulus), [Matrix](https://matrix.to/#/%40lassulus:lassul.us), [Discourse](https://discourse.nixos.org/u/lassulus))
+- Pablo (Github: [@pinpox](https://github.com/pinpox), [Matrix](https://matrix.to/#/%40pinpox:matrix.org), [Discourse](https://discourse.nixos.org/u/pinpox))
+- Raphael (Github: [@das-g](https://github.com/das-g), [Matrix](https://matrix.to/#/%40das-g:matrix.org), [Discourse](https://discourse.nixos.org/u/das-g))
+- Ron (Github: [@refroni](https://github.com/refroni), [Matrix](https://matrix.to/#/%40ronef:matrix.org), [Discourse](https://discourse.nixos.org/u/ron))
+- Sebastian (GitHub: [@ra33it0](https://github.com/ra33it0), [Matrix](https://matrix.to/#/%40ra33it0:matrix.org), [Discourse](https://discourse.nixos.org/u/ra33it0))
+- Silvan (Github: [@infinisil](https://github.com/infinisil), [Matrix](https://matrix.to/#/%40infinisil:matrix.org), [Discourse](https://discourse.nixos.org/u/infinisil))
+
+Organisers are using:
+- This GitHub issue for general updates: https://github.com/NixOS/org/issues/70
+- This Matrix room for async discussions: [#nixcon2025-orga:lassul.us](https://matrix.to/#/%23nixcon2025-orga:lassul.us)
+- This alias-only Email address: <nixcon@nixos.org>
+- This GitHub repository to host the website: https://github.com/nixcon/2025.nixcon.org/
+
+If the organisers cannot reach consensus on important decisions,
+they are escalated to the Steering Committee.
+Decisions relating to sponsorships are always escalated to the Steering Committee.

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -21,7 +21,7 @@ These are the organisers (ordered alphabetically):
 - Alex (Github: [@ners](https://github.com/ners), [Matrix](https://matrix.to/#/%40ners:nixos.dev), [Discourse](https://discourse.nixos.org/u/ners))
 - Andreas (Github: [@Nebucatnetzer](https://github.com/Nebucatnetzer), [Matrix](https://matrix.to/#/%40nebucatnetzer13:matrix.org), [Discourse](https://discourse.nixos.org/u/Nebucatnetzer))
 - Andreas (GitHub: [@andir](https://github.com/andir), [Matrix](https://matrix.to/#/%40andi:kack.it), [Discourse](https://discourse.nixos.org/u/andir))
-- Berber (Github: [@zmberber](https://github.com/zmberber), [Matrix](@andi:kack.itzmberber:matrix.org), [Discourse](andirzmberber))
+- Berber (Github: [@zmberber](https://github.com/zmberber), [Matrix](https://matrix.to/#/%40zmberber:matrix.org), [Discourse](https://discourse.nixos.org/u/zmberber))
 - John (Github: [@john-rodewald](https://github.com/john-rodewald), [Matrix](https://matrix.to/#/%40john-rodewald:nixos.dev), [Discourse](https://discourse.nixos.org/u/john-rodewald))
 - Kenji (Github: [@a-kenji](https://github.com/a-kenji), [Matrix](https://matrix.to/#/%40a-kenji:matrix.org), [Discourse](https://discourse.nixos.org/u/a-kenji))
 - Lassulus (Github: [@lassulus](https://github.com/lassulus), [Matrix](https://matrix.to/#/%40lassulus:lassul.us), [Discourse](https://discourse.nixos.org/u/lassulus))


### PR DESCRIPTION
As mentioned in #70, we had a first meeting today to start organisation of NixCon 2025. Present were @zmberber, @a-kenji, @lassulus, @pinpox, @refroni, @Nebucatnetzer and @infinisil. While @Nebucatnetzer and @infinisil are local, the more experienced local event organisers @ners, @john-rodewald and @das-g could not attend this first meeting.

In the meeting we agreed to now work with the assumption that NixCon 2025 _will_ be held at [OST Rapperswil-Jona (Switzerland)](https://github.com/nixcon/nixcon-proposals/issues/4#event-13200457377). While there are many things to figure out still, **if we can make OST Rapperswil-Jona happen, let's make it happen**.

Furthermore, we generally agreed that:
- NixCon should be made official and we should be delegated explicitly as organisers for this year.
- If we cannot reach consensus on important decisions, they are escalated to the Steering Committee.
- Decisions relating to sponsorships are always escalated to the Steering Committee.

This PR is still a draft because we should get confirmation from @ners, @john-rodewald and @das-g for the location and for the vital local organisation.

This needs to be approved by the SC. To implement this PR, the following also needs to happen:
- The owners of the both [NixOS](https://github.com/nixos) and [NixCon](https://github.com/nixcon) GitHub organisations should be made to match (@zimbatm or @lassulus can implement this)
- The <nixcon@nixos.org> email should be aliased to the organisers (infra team can implement this, @infinisil has the list of emails). Related: #75 
- The https://github.com/nixcon/2025.nixcon.org/ repository should be created, the organisators should be given write access to it

This PR closes https://github.com/NixOS/org/issues/22