### PR TITLE
Sync nixcon organiser mail recipients

### DIFF
--- a/doc/mail.md
+++ b/doc/mail.md
@@ -97,6 +97,8 @@ ImprovMX is configured to forward emails on the following addresses to the respe
   - [@a-kenji](https://github.com/a-kenji)
   - [@lassulus](https://github.com/lassulus)
   - [@pinpox](https://github.com/pinpox)
+  - [@ForsakenHarmony](https://github.com/ForsakenHarmony)
+  - [@idabzo](https://github.com/idabzo)
 
 Emails can only be sent from the following addresses:
 - winter@nixos.org: For [@winterqt](https://github.com/winterqt)

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -23,7 +23,7 @@ These are the organisers (ordered alphabetically):
 - Andreas (GitHub: [@andir](https://github.com/andir), [Matrix](https://matrix.to/#/%40andi:kack.it), [Discourse](https://discourse.nixos.org/u/andir))
 - Berber (Github: [@zmberber](https://github.com/zmberber), [Matrix](https://matrix.to/#/%40zmberber:matrix.org), [Discourse](https://discourse.nixos.org/u/zmberber))
 - Ida (Github: [@idabzo](https://github.com/idabzo), [Matrix](https://matrix.to/#/%40idabzo:matrix.org), [Discourse](https://discourse.nixos.org/u/idabzo))
-- hrmny (Github: [@hrmny](https://github.com/ForsakenHarmony), [Matrix](https://matrix.to/#/%40hrmny:matrix.org), [Discourse](https://discourse.nixos.org/u/hrmny))
+- hrmny (Github: [@ForsakenHarmony](https://github.com/ForsakenHarmony), [Matrix](https://matrix.to/#/%40hrmny:matrix.org), [Discourse](https://discourse.nixos.org/u/hrmny))
 - John (Github: [@john-rodewald](https://github.com/john-rodewald), [Matrix](https://matrix.to/#/%40john-rodewald:nixos.dev), [Discourse](https://discourse.nixos.org/u/john-rodewald))
 - Kenji (Github: [@a-kenji](https://github.com/a-kenji), [Matrix](https://matrix.to/#/%40a-kenji:matrix.org), [Discourse](https://discourse.nixos.org/u/a-kenji))
 - Lassulus (Github: [@lassulus](https://github.com/lassulus), [Matrix](https://matrix.to/#/%40lassulus:lassul.us), [Discourse](https://discourse.nixos.org/u/lassulus))


### PR DESCRIPTION
This adds @ForsakenHarmony and @idabzo to the nixcon@nixos.org email alias, follow-up to #83.

@ForsakenHarmony @idabzo: Please PM the email you want to use to the person from the infra team implementing this PR (probably @mweinelt :))