### PR TITLE
Remove outdated account from google calendar access

### DIFF
--- a/doc/calendar.md
+++ b/doc/calendar.md
@@ -10,4 +10,3 @@ These Google accounts have access to manage permissions (and make changes to eve
 
 These Google accounts can only make changes to events:
 - silvan.mosberger@moduscreate.com (@infinisil)
-- nixpkgs-architecture@infinisil.com (@infinisil)


### PR DESCRIPTION
To implement, an admin of the calendar needs to remove this email