### PR TITLE
use personal email address

### DIFF
--- a/doc/calendar.md
+++ b/doc/calendar.md
@@ -6,7 +6,7 @@ These Google accounts have access to manage permissions (and make changes to eve
 <!-- Keep this list in sync with the codeowners of this file! -->
 - edolstra@gmail.com (@edolstra)
 - tomberek@gmail.com (@tomberek)
-- valentin.gagarin@moduscreate.com (@fricklerhandwerk)
+- valentin.gagarin@gmail.com (@fricklerhandwerk)
 
 These Google accounts can only make changes to events:
 - silvan.mosberger@moduscreate.com (@infinisil)


### PR DESCRIPTION
I'm almost always wearing my own hat when doing NixOS org-level things, this change reflects that.

This change is already implemented.