### PR TITLE
Add NixCon sponsorship tiers and process

### DIFF
--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -102,15 +102,15 @@ Send an email to sponsor@nixos.org (which will forward to both the Nix Steering 
 
 ## Sponsorship process
 
-The following is internal documentation and should not go on the website. It involves the following respondents:
+The following is internal documentation and should not go on the website. For 2025 it involves the following respondents:
 - Board respondent: @infinisil or @ra33it0?
 - SC respondent: ???
 
 1. After receiving the email, board respondent replies that the email was received and that they will hear back within about 2 weeks.
 2. SC respondent ensures the SC internally rejects or provisionally approves the sponsor within 1 week.
    - If rejected, SC respondent replies to the sponsor with the rejection message.
-3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the [NixCon 2025 orga Matrix room](https://matrix.to/#/%23nixcon2025-orga:lassul.us) for organiser approval.
+3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the NixCon orga Matrix room for organiser approval.
 4. Within 1 week, the SC respondent checks whether organisers are okay with the sponsor, and if not, ensures that the SC internally reevaluates final rejection or approval of the sponsor.
    - If rejected, SC respondent replies to the sponsor with the rejection message.
-5. If accepted, SC informs the board respondent and the organisers in the [NixCon 2025 orga Matrix room](https://matrix.to/#/%23nixcon2025-orga:lassul.us) of the sponsor being accepted.
+5. If accepted, SC informs the board respondent and the organisers in the NixCon orga Matrix room of the sponsor being accepted.
 6. Board respondent sends follow-up instructions to the sponsor and tracks the status of payment and perk delivery.

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -91,7 +91,7 @@ This should be displayed on the website.
 - Visibility priority is given according to tiers and donation amount.
 - The sponsor can selectively abstain from perks.
 - Surplus funds will be used to support official Nix projects.
-- Reach out if you'd like to sponsor in a more custom way, such as food, drinks or only specific perks.
+- Reach out if you'd like to sponsor in a more custom way, such as food, drinks, services, equipment, or only specific perks.
 
 ### How to sponsor
 

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -56,22 +56,22 @@ This should be displayed on the website.
 - Linked logo on the website
 - Linked shout-out or repost from official social media accounts
 - Possibility to distribute your own stickers/swag/merch at the venue
-- Tickets: 1 corporate tickets[^1]
+- Tickets: 1+ corporate tickets[^1]
 
-[^1]: Only corporate tickets come with company name/logo recognition on the badge. Corporate tickets can also be bought individually when ticket sales open.
+[^1]: One corporate ticket per 1024 EUR. Only corporate tickets come with company name/logo recognition on the badge. Corporate tickets can also be bought individually when ticket sales open.
 
 ### Silver (2048+ EUR)
 - Everything from Bronze
 - Shout-out in the opening
 - Slot on break slideshow (provide a slide in advance)
 - Possibility to distribute flyers (provide them in advance) to all attendees in bag
-- Tickets: 2 corporate tickets[^1]
+- Tickets: 2+ corporate tickets[^1]
 
 ### Gold (4096+ EUR):
 - Everything from Silver
 - 5 minute lightning talk slot
 - Dedicated space for a booth[^2]
-- Tickets: 4 corporate tickets[^1]
+- Tickets: 4+ corporate tickets[^1]
 
 [^2]: These perks may be limited in availability.
 
@@ -81,7 +81,7 @@ This should be displayed on the website.
 - 1 minute presentation slot (provide the slides in advance) in the conference opening
 - Intro of all recordings show your name/logo
 - Possibility to distribute items (provide them in advance) to all attendees in bag
-- Tickets: 8 corporate tickets[^1]
+- Tickets: 8+ corporate tickets[^1]
 
 [^3]: These perks require production and cannot be guaranteed if too late.
 

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -43,3 +43,74 @@ Organisers are using:
 If the organisers cannot reach consensus on important decisions,
 they are escalated to the Steering Committee.
 Decisions relating to sponsorships are always escalated to the Steering Committee.
+
+## Sponsorship tiers
+
+This should be displayed on the website.
+
+### Non-sponsorship donation (0+ EUR)
+- Supporting the conference and official Nix projects
+- Confirmation of donation via OpenCollective
+
+### Bronze (1000+ EUR):
+- Linked logo on the website
+- Linked shout-out or repost from official social media accounts
+- Possibility to distribute your own stickers/swag/merch at the venue
+- Tickets: 1 corporate tickets[^1]
+
+[^1]: Only corporate tickets come with company name/logo recognition on the badge. Corporate tickets can also be bought individually when ticket sales open.
+
+### Silver (3000+ EUR)
+- Everything from Bronze
+- Shout-out in the opening
+- Slot on break slideshow (provide a slide in advance)
+- Possibility to distribute flyers (provide them in advance) to all attendees in bag
+- Tickets: 3 corporate tickets[^1]
+
+### Gold (5000+ EUR):
+- Everything from Silver
+- 5 minute lightning talk slot
+- Dedicated space for a booth[^2]
+- Tickets: 5 corporate tickets[^1]
+
+[^2]: These perks may be limited in availability.
+
+### Diamond (10000+ EUR):
+- Everything from Gold
+- Logo on some official conference swag[^2][^3]
+- 1 minute presentation slot (provide the slides in advance) in the conference opening
+- Intro of all recordings show your name/logo
+- Possibility to distribute items (provide them in advance) to all attendees in bag
+- Tickets: 10 corporate tickets[^1]
+
+[^3]: These perks require production and cannot be guaranteed if too late.
+
+### General info
+- Sponsors can be tier-limited or rejected by the Nix Steering Committee for any reason.
+- The outline of all sponsor content must be disclosed in advance. We reserve the right to reject content.
+- Visibility priority is given according to tiers and donation amount.
+- The sponsor can selectively abstain from perks.
+- Surplus funds will be used to support official Nix projects.
+- Reach out if you'd like to sponsor in a more custom way, such as food, drinks or only specific perks.
+
+### How to sponsor
+
+Send an email to sponsor@nixos.org (which will forward to both the Nix Steering Committee and the NixOS Foundation board) with:
+- Company name and website
+- Desired tier, amount and perks
+- Any other details
+
+## Sponsorship process
+
+The following is internal documentation and should not go on the website. It involves the following respondents:
+- Board respondent: @infinisil or @ra33it0?
+- SC respondent: ???
+
+1. After receiving the email, board respondent replies that the email was received and that they will hear back within about 2 weeks.
+2. SC respondent ensures the SC internally rejects or provisionally approves the sponsor within 1 week.
+   - If rejected, SC respondent replies to the sponsor with the rejection message.
+3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the [NixCon 2025 orga Matrix room](https://matrix.to/#/%23nixcon2025-orga:lassul.us) for organiser approval.
+4. Within 1 week, the SC respondent checks whether organisers are okay with the sponsor, and if not, ensures that the SC internally reevaluates final rejection or approval of the sponsor.
+   - If rejected, SC respondent replies to the sponsor with the rejection message.
+5. If accepted, SC informs the board respondent and the organisers in the [NixCon 2025 orga Matrix room](https://matrix.to/#/%23nixcon2025-orga:lassul.us) of the sponsor being accepted.
+6. Board respondent sends follow-up instructions to the sponsor and tracks the status of payment and perk delivery.

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -52,7 +52,7 @@ This should be displayed on the website.
 - Supporting the conference and official Nix projects
 - Confirmation of donation via OpenCollective
 
-### Bronze (1000+ EUR):
+### Bronze (1024+ EUR):
 - Linked logo on the website
 - Linked shout-out or repost from official social media accounts
 - Possibility to distribute your own stickers/swag/merch at the venue
@@ -60,28 +60,28 @@ This should be displayed on the website.
 
 [^1]: Only corporate tickets come with company name/logo recognition on the badge. Corporate tickets can also be bought individually when ticket sales open.
 
-### Silver (3000+ EUR)
+### Silver (2048+ EUR)
 - Everything from Bronze
 - Shout-out in the opening
 - Slot on break slideshow (provide a slide in advance)
 - Possibility to distribute flyers (provide them in advance) to all attendees in bag
-- Tickets: 3 corporate tickets[^1]
+- Tickets: 2 corporate tickets[^1]
 
-### Gold (5000+ EUR):
+### Gold (4096+ EUR):
 - Everything from Silver
 - 5 minute lightning talk slot
 - Dedicated space for a booth[^2]
-- Tickets: 5 corporate tickets[^1]
+- Tickets: 4 corporate tickets[^1]
 
 [^2]: These perks may be limited in availability.
 
-### Diamond (10000+ EUR):
+### Diamond (8192+ EUR):
 - Everything from Gold
 - Logo on some official conference swag[^2][^3]
 - 1 minute presentation slot (provide the slides in advance) in the conference opening
 - Intro of all recordings show your name/logo
 - Possibility to distribute items (provide them in advance) to all attendees in bag
-- Tickets: 10 corporate tickets[^1]
+- Tickets: 8 corporate tickets[^1]
 
 [^3]: These perks require production and cannot be guaranteed if too late.
 

--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -103,8 +103,8 @@ Send an email to sponsor@nixos.org (which will forward to both the Nix Steering 
 ## Sponsorship process
 
 The following is internal documentation and should not go on the website. For 2025 it involves the following respondents:
-- Board respondent: @infinisil or @ra33it0?
-- SC respondent: ???
+- Board respondent: @ra33it0 (deputy: @infinisil)
+- SC respondent: @tomberek (deputy: @winterqt)
 
 1. After receiving the email, board respondent replies that the email was received and that they will hear back within about 2 weeks.
 2. SC respondent ensures the SC internally rejects or provisionally approves the sponsor within 1 week.


### PR DESCRIPTION
Already early in NixCon 2025 planning, we organisers reached consensus to make sponsoring possible again this year, after they were forgone entirely last year. We'd like to make the tickets be as close to free as possible, considering that this years location in Switzerland is a bit more expensive to stay at. With enough funds, we could even consider extras, like meals, stipends, etc.

This PR is the next step towards making that a reality, by defining the sponsorship tiers and process. As indicated [in the constitution](https://github.com/NixOS/org/blob/b433b5f9a071fe48299f6feed41c4fee31fb854f/doc/constitution.md?plain=1#L61), both the @NixOS/steering committee and the @NixOS/foundation board need to approve this.

We'd like to get this approved as soon as possible, so we can put the tiers on the NixCon website (which is being worked on) and start receiving sponsorships. This way we can get an early idea of the available budget and plan for a better event.

The tiers proposed here were initially drafted by board members and later refined with feedback from the [NixCon 2025 organisers](https://github.com/NixOS/org/blob/main/doc/nixcon.md#nixcon-2025-rapperswil-jona-switzerland). The process was drafted by me and @Lassulus.

Ping for the NixCon 2025 organisers for visibility: @ners @Nebucatnetzer @andir @zmberber @idabzo @ForsakenHarmony @john-rodewald @a-kenji @lassulus @pinpox @picnoir @das-g @refroni @ra33it0 @infinisil