### PR TITLE
Introduce github-mgmt repository

### DIFF
--- a/doc/github.md
+++ b/doc/github.md
@@ -64,6 +64,12 @@ The home of the branding guide and media kit.
 
 The [marketing team](https://nixos.org/community/teams/marketing/) controls this repository.
 
+### [github-mgmt](https://github.com/NixOS/github-mgmt)
+
+Bi-directionally syncs a subset of the GitHub org settings.
+
+The [GitHub org owners](./github-org-owners.md) own this repository.
+
 ## Groups
 
 ### [nixpkgs-committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers)


### PR DESCRIPTION
After me and @winterqt have [experimented](https://github.com/Infinisil-s-Test-Organization/github-as-code) with the suggestion in NixOS/org#40 of using [github-as-code](https://github.com/ipdxco/github-as-code), we're confident that we should deploy for real, so that people can more easily request GitHub org changes by just making PRs.

As this is strictly outside the [authority of the org owners](https://github.com/NixOS/org/blob/main/doc/github-org-owners.md#authority-and-processes), I am hereby formally requesting @NixOS/steering approval to **give the org owners authority over the deployment of github-as-code**.

Some notes:
- github-as-code _bi-directionally_ syncs changes, so any imperative changes to the GitHub org will get synced back to the repo automatically, it will not interfere with that. But in addition, merged PRs will get synced to the GitHub org too.
- Only the org owners will be able to make changes to the repo for a start, but this could be expanded in the future with good file separation and codeowner declarations like the org repo.
- We'll only use it for team memberships to start out
  - Should have an exception for the Nixpkgs maintainers team, depends on https://github.com/ipdxco/github-as-code/pull/162
- This will pave the way towards https://github.com/NixOS/nixpkgs-committers/issues/62 (which I'd also still like SC approval on)