### PR TITLE
Don't require CIVS

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -155,7 +155,7 @@ After the nomination deadline, the SC can prevent a nominee from becoming a cand
 
 #### Procedure
 
-The election is done using a [proportional representation mode from Condorcet Internet Voting Service (CIVS)](http://web.archive.org/web/20240412235900/https://civs1.civs.us/proportional.html). The recommendation is to use [CIVS](https://civs1.civs.us/) itself, but if CIVS is unavailable, a reasonable alternative proportional representation election implementation is also permitted.
+The election is done using a propotional representation oriented tallying system based on ranked ballots. One option is to use [proportional representation mode from Condorcet Internet Voting Service (CIVS)](http://web.archive.org/web/20240412235900/https://civs1.civs.us/proportional.html), but a reasonable alternative is also permitted.
 
 In any election where seats with different end-of-term dates are available, winning candidates with higher final election rankings are appointed to the longer terms.
 

--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -155,7 +155,7 @@ After the nomination deadline, the SC can prevent a nominee from becoming a cand
 
 #### Procedure
 
-The election is done using a propotional representation oriented tallying system based on ranked ballots. One option is to use [proportional representation mode from Condorcet Internet Voting Service (CIVS)](http://web.archive.org/web/20240412235900/https://civs1.civs.us/proportional.html), but a reasonable alternative is also permitted.
+The election is done using a proportional representation oriented tallying system based on ranked ballots. One option is to use [proportional representation mode from Condorcet Internet Voting Service (CIVS)](http://web.archive.org/web/20240412235900/https://civs1.civs.us/proportional.html), but a reasonable alternative is also permitted.
 
 In any election where seats with different end-of-term dates are available, winning candidates with higher final election rankings are appointed to the longer terms.
 


### PR DESCRIPTION
The last election has shown that CIVS is not very suitable for collecting votes (the UX and control features are not conductive to high voter turnout), and only using CIVS for tallying the votes (which was done last time) adds a lot of complication, when OpaVote's tallying methods plentyful and sufficient, even if not matching CIVS to the dot.

It should be up to the EC to decide whether they want to use CIVS or a reasonable alternative, and not be prescribed by the constitution.

This was brought up by @7c6f434c, ping @NixOS/ec-2024

As this is a constitutional amendment, it needs a 5/7 SC supermajority to be approved