### PR TITLE
nixpkgs-committers: Remove myself from the nixpkgs committer delegation team

### DIFF
--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -9,7 +9,6 @@ The [Nixpkgs committer delegation team](#team) is given the responsibility and a
 
 Nixpkgs committer delegation team consists of these people:
 
-- [@Mic92](https://github.com/Mic92)
 - [@NickCao](https://github.com/NickCao) ([Matrix](https://matrix.to/#/@nickcao:nichi.co), [Discourse](https://discourse.nixos.org/u/nickcao))
 - [@jtojnar](https://github.com/jtojnar) ([Matrix](https://matrix.to/#/@jtojnar:matrix.org), [Discourse](https://discourse.nixos.org/u/jtojnar))
 


### PR DESCRIPTION
Remove myself from the nixpkgs committer delegation team. This has already been the case for some time but this reference hasn't been updated yet.