### PR TITLE
Committers process update

### DIFF
--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -18,4 +18,6 @@ They can be contacted either individually, or through a [group message on Discou
 ## Process
 - The process must be publicly documented (this document)
 - Any change to the process must be unanimously agreed upon by all delegation team members
-- Any change in the list of committers must be publicly documented and agreed upon by all delegation team members
+- Any change in the list of committers must be publicly documented
+- Addition of a committer must be agreed upon by all delegation team members
+- Removal of a committer only requires agreement of a single delegation team member

--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -8,7 +8,7 @@ The [Nixpkgs committer delegation team](#team) is given the responsibility and a
 ## Team
 
 Nixpkgs committer delegation team consists of these people:
-
+<!-- Keep this list in sync with the codeowners of this file! -->
 - [@NickCao](https://github.com/NickCao) ([Matrix](https://matrix.to/#/@nickcao:nichi.co), [Discourse](https://discourse.nixos.org/u/nickcao))
 - [@jtojnar](https://github.com/jtojnar) ([Matrix](https://matrix.to/#/@jtojnar:matrix.org), [Discourse](https://discourse.nixos.org/u/jtojnar))
 - [@winterqt](https://github.com/winterqt) ([Matrix](https://matrix.to/#/@winter:catgirl.cloud), [Discourse](https://discourse.nixos.org/u/winter))


### PR DESCRIPTION
This ensures that all commit delegators can always be comfortable with all committers.

CC @winterqt 

Note that as this changes the commit delegation process, it needs approval from all commit delegators.