### PR TITLE
Make NixCon more official

### DIFF
--- a/doc/github.md
+++ b/doc/github.md
@@ -1,6 +1,7 @@
 # GitHub
 
-The [NixOS GitHub organisation](https://github.com/nixos) and all its repositories is part of the [official resources](./resources.md).
+The [NixOS](https://github.com/nixos) and [NixCon](https://github.com/nixcon) GitHub organisations,
+as well as all their repositories are part of the [official resources](./resources.md).
 
 The org owners documentation is [here](./github-org-owners.md).
 
@@ -37,6 +38,12 @@ The source for https://nix.dev.
 
 The [documentation team](https://nixos.org/community/teams/documentation/) controls this repository.
 
+### NixCon
+
+The repositories under the [the NixCon organisation](https://github.com/nixcon) contain
+the sources of NixCon websites from different years, as well as
+tools and resources used by [NixCon organisers](./nixcon.md).
+
 ### [rfcs](https://github.com/NixOS/rfcs)
 
 The Nix community RFCs, see also [here](./governance.md#rfc-process).
@@ -63,11 +70,11 @@ The [marketing team](https://nixos.org/community/teams/marketing/) controls this
 
 ## Groups
 
-### [nixpkgs-committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers)
+### [NixOS/nixpkgs-committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers)
 
 Documented in [./nixpkgs-committers.md](./nixpkgs-committers.md).
 
-### [nixpkgs-maintainers](https://github.com/orgs/NixOS/teams/nixpkgs-maintainers)
+### [NixOS/nixpkgs-maintainers](https://github.com/orgs/NixOS/teams/nixpkgs-maintainers)
 
 A very large group of contributors established by [RFC 39](https://github.com/NixOS/rfcs/blob/master/rfcs/0039-unprivileged-maintainer-teams.md).
 

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -29,9 +29,15 @@ A secondary domain is `nix.dev`, which hosts [the main documentation](https://ni
 See the [infra repository](https://github.com/nixos/infra) for more information.
 To request permissions or changes to the infrastructure, get in touch with the [infrastructure team](https://nixos.org/community/teams/infrastructure/).
 
+[NixCon](./nixcon.md) has a separate domain – `nixos.org` – with subdomains dedicated to
+each individual event (such as [NixCon 2025](https://2025.nixcon.org/)) and various
+conference-related secondary resources.
+
 ## GitHub
 
-The [NixOS GitHub organisation](https://github.com/nixos) and all its repositories.
+- The [NixOS GitHub organisation](https://github.com/nixos) and all its repositories.
+- The [NixCon GitHub organisation](https://github.com/nixcon) and all its repositories.
+
 See [this page](./github.md) for more information.
 
 ## Other third-party accounts


### PR DESCRIPTION
* Make nixcon.org an official domain
* Explicitly say that the NixCon GitHub org and its repos are official
* Add more links to nixcon.md from other files

Follow up to #74.