### PR TITLE
nixcon: Tune the sponsorship approval process

### DIFF
--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -94,8 +94,8 @@ The following is internal documentation and should not go on the website. For 20
 1. After receiving the email, board respondent replies that the email was received and that they will hear back within about 2 weeks.
 2. SC respondent ensures the SC internally rejects or provisionally approves the sponsor within 1 week.
    - If rejected, SC respondent replies to the sponsor with the rejection message.
-3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the NixCon orga Matrix room for organiser approval.
-4. Within 1 week, the SC respondent checks whether organisers are okay with the sponsor, and if not, ensures that the SC internally reevaluates final rejection or approval of the sponsor.
+3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the NixCon orga Matrix room for organiser approval, who have 2 days to issue objections.
+4. Within 1 week, the SC respondent checks whether organisers have issued objections, and if so, ensures that the SC internally reevaluates final rejection or approval of the sponsor.
    - If rejected, SC respondent replies to the sponsor with the rejection message.
 5. If accepted, SC informs the board respondent and the organisers in the NixCon orga Matrix room of the sponsor being accepted.
 6. Board respondent sends follow-up instructions to the sponsor and tracks the status of payment and perk delivery.


### PR DESCRIPTION
Before, there was the implied requirement to wait on organiser objections for 1 week, with no way to skip if the sponsor is uncontroversial.

This commit refines it to be clear that organisers should issue objections within 2 days, and only if any objections are issued within that time, the SC needs to reevaluate whether the sponsor can be approved.

This allows speeding up the sponsor approval process.

This change is somewhat weakening the NixCon organisers power over sponsorships, I'll collect organiser feedback on this tomorrow. If there's no objections, I think this can go ahead with just a single SC approval.