### PR TITLE
Switch nixpkgs to branch protection rulesets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /npins @NixOS/org
 /default.nix @NixOS/org
 /shell.nix @NixOS/org
+/rulesets @NixOS/org
 
 /doc/org-repo.md @NixOS/steering
 /doc/discourse.md @NixOS/steering @mweinelt @picnoir @lassulus @jtojnar @ctheune @dpausp

--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -1,0 +1,9 @@
+This directory contains JSON exports of [branch protection rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) for repositories in the NixOS org.
+
+They are not managed automatically, but can easily be imported by org owners.
+To propose changes to branch protection rules, you can open a Pull Request.
+
+After making changes to those rulesets, please export them again.
+This can be done with the `./export.bash` script.
+For example, to export the rulesets for the `nixpkgs` repo, call `rulesets/export.bash nixpkgs`.
+While the rulesets endpoint can be read by non-owners, the export must be done by an org-owner to include the `bypass_actors` field.

--- a/rulesets/export.bash
+++ b/rulesets/export.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p gh jq
+set -euo pipefail
+
+REPO="${1:?Please pass the repository name as the only argument.}"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+gh api "/repos/NixOS/$REPO/rulesets" --jq '.[] | "\(._links.self.href) \(.name)"' \
+	| xargs -n2 sh -c "gh api \$0 | jq 'del(.node_id, ._links)' > $REPO/\$1.json"

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -18,5 +18,8 @@
       "type": "creation"
     }
   ],
-  "bypass_actors": []
+  "created_at": "2025-06-11T20:44:19.501+02:00",
+  "updated_at": "2025-06-11T20:44:19.501+02:00",
+  "bypass_actors": [],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -1,0 +1,22 @@
+{
+  "id": 6007205,
+  "name": "no-creation",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007205,
+  "id": 6008904,
   "name": "no-creation",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/rulesets/nixpkgs/no-delete.json
+++ b/rulesets/nixpkgs/no-delete.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007029,
+  "id": 6008908,
   "name": "no-delete",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/rulesets/nixpkgs/no-delete.json
+++ b/rulesets/nixpkgs/no-delete.json
@@ -25,5 +25,8 @@
       "type": "deletion"
     }
   ],
-  "bypass_actors": []
+  "created_at": "2025-06-11T20:45:03.450+02:00",
+  "updated_at": "2025-06-11T20:45:03.450+02:00",
+  "bypass_actors": [],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/no-delete.json
+++ b/rulesets/nixpkgs/no-delete.json
@@ -1,0 +1,29 @@
+{
+  "id": 6007029,
+  "name": "no-delete",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release*",
+        "refs/heads/staging*",
+        "refs/heads/nixos-*",
+        "refs/heads/nixpkgs-*",
+        "refs/heads/haskell-updates",
+        "refs/heads/r-updates",
+        "refs/heads/python-updates"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/rulesets/nixpkgs/no-force-push-except-release-team.json
+++ b/rulesets/nixpkgs/no-force-push-except-release-team.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007152,
+  "id": 6008917,
   "name": "no-force-push-except-release-team",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/rulesets/nixpkgs/no-force-push-except-release-team.json
+++ b/rulesets/nixpkgs/no-force-push-except-release-team.json
@@ -1,0 +1,28 @@
+{
+  "id": 6007152,
+  "name": "no-force-push-except-release-team",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/staging*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3620128,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/rulesets/nixpkgs/no-force-push-except-release-team.json
+++ b/rulesets/nixpkgs/no-force-push-except-release-team.json
@@ -18,11 +18,14 @@
       "type": "non_fast_forward"
     }
   ],
+  "created_at": "2025-06-11T20:46:09.215+02:00",
+  "updated_at": "2025-06-11T20:46:09.215+02:00",
   "bypass_actors": [
     {
       "actor_id": 3620128,
       "actor_type": "Team",
       "bypass_mode": "always"
     }
-  ]
+  ],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/no-force-push.json
+++ b/rulesets/nixpkgs/no-force-push.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007056,
+  "id": 6008913,
   "name": "no-force-push",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/rulesets/nixpkgs/no-force-push.json
+++ b/rulesets/nixpkgs/no-force-push.json
@@ -1,0 +1,26 @@
+{
+  "id": 6007056,
+  "name": "no-force-push",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release*",
+        "refs/heads/nixos-*",
+        "refs/heads/nixpkgs-*",
+        "refs/heads/haskell-updates"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/rulesets/nixpkgs/no-force-push.json
+++ b/rulesets/nixpkgs/no-force-push.json
@@ -22,5 +22,8 @@
       "type": "non_fast_forward"
     }
   ],
-  "bypass_actors": []
+  "created_at": "2025-06-11T20:45:33.529+02:00",
+  "updated_at": "2025-06-11T20:45:33.529+02:00",
+  "bypass_actors": [],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/no-updates-except-channel-updaters.json
+++ b/rulesets/nixpkgs/no-updates-except-channel-updaters.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007273,
+  "id": 6008921,
   "name": "no-updates-except-channel-updaters",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -16,10 +16,7 @@
   },
   "rules": [
     {
-      "type": "update",
-      "parameters": {
-        "update_allows_fetch_and_merge": false
-      }
+      "type": "update"
     }
   ],
   "bypass_actors": [

--- a/rulesets/nixpkgs/no-updates-except-channel-updaters.json
+++ b/rulesets/nixpkgs/no-updates-except-channel-updaters.json
@@ -19,11 +19,14 @@
       "type": "update"
     }
   ],
+  "created_at": "2025-06-11T20:46:53.734+02:00",
+  "updated_at": "2025-06-11T20:46:53.734+02:00",
   "bypass_actors": [
     {
       "actor_id": 3475569,
       "actor_type": "Team",
       "bypass_mode": "always"
     }
-  ]
+  ],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/no-updates-except-channel-updaters.json
+++ b/rulesets/nixpkgs/no-updates-except-channel-updaters.json
@@ -1,0 +1,32 @@
+{
+  "id": 6007273,
+  "name": "no-updates-except-channel-updaters",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/nixos-*",
+        "refs/heads/nixpkgs-*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "update",
+      "parameters": {
+        "update_allows_fetch_and_merge": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3475569,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/rulesets/nixpkgs/require-pull-request-except-release-team.json
+++ b/rulesets/nixpkgs/require-pull-request-except-release-team.json
@@ -1,9 +1,9 @@
 {
-  "id": 6007320,
+  "id": 6008941,
   "name": "require-pull-request-except-release-team",
   "target": "branch",
   "source_type": "Repository",
-  "source": "wolfgangwalther/nixpkgs",
+  "source": "NixOS/nixpkgs",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/rulesets/nixpkgs/require-pull-request-except-release-team.json
+++ b/rulesets/nixpkgs/require-pull-request-except-release-team.json
@@ -32,11 +32,14 @@
       }
     }
   ],
+  "created_at": "2025-06-11T20:48:04.174+02:00",
+  "updated_at": "2025-06-11T20:48:04.174+02:00",
   "bypass_actors": [
     {
       "actor_id": 3620128,
       "actor_type": "Team",
       "bypass_mode": "always"
     }
-  ]
+  ],
+  "current_user_can_bypass": "never"
 }

--- a/rulesets/nixpkgs/require-pull-request-except-release-team.json
+++ b/rulesets/nixpkgs/require-pull-request-except-release-team.json
@@ -1,0 +1,42 @@
+{
+  "id": 6007320,
+  "name": "require-pull-request-except-release-team",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "wolfgangwalther/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3620128,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
This PR is not necessarily intended to be merged\*. It targets #120, but discussing code in a Pull Request is easier than in an issue. Those files are supposed to be *imported* into the nixpkgs branch protection rulesets section.

Those files have been created in my fork and were then exported. The only modification I made manually is in the `bypass_actors` section. Since I can't have any teams in my personal fork, I added those manually. Hopefully that works, it should according to API docs etc.

The Team ID's can be verified with:
```bash
gh api /orgs/NixOS/teams/channel-updaters

gh api /orgs/NixOS/teams/nixos-release-managers
```

The general structure is different compared to the classic branch protection rules, because the features are slightly different. The new rulesets can only define bypassers for the whole ruleset, not for some of the rules in it. Thus, the different rules must be separated to replicate the status-quo.

AFAICT, this should replicate the [status-quo](https://gist.github.com/infinisil/33fdbb637e719a9ebeb46010b4761861) exactly. Of course, careful review is required.

@infinisil 

---

\*If, however, we want to document those rules here, then they should be re-exported after import.