### PR TITLE
Resolve an accidental ambiguity in the constitution

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -151,7 +151,7 @@ The requirements to become a candidate for the SC elections are:
 - To not have any conflicts of interest that would [prevent one from being appointed](#conflict-of-interest-coi-balance) to the SC, and publicly disclose all potential conflicts of interest
   - This includes conflicts of interest to arise during the term based on already finalised agreements
 
-After the nomination deadline, the SC can prevent a nominee from becoming a candidate by unanimity (among the currently serving non-running members of the SC) in case their public image or conduct would not be compatible with the position in the SC.
+After the nomination deadline, the SC can prevent a nominee from becoming a candidate by supermajority (among the currently serving members of the SC) in case their public image or conduct would not be compatible with the position in the SC.
 
 #### Procedure
 


### PR DESCRIPTION
Resolve an accidental ambiguity in the constitution left in by the NCA. This PR needs 5/7 supermajority approval from the @NixOS/steering to be merged. @NixOS/nix-constitutional-assembly can attest the records and that this change was intended.

Without this PR, there is an ambiguity as to how candidates can be disqualified from the election:
- [This part](https://github.com/NixOS/org/blob/bd3ca5a88af0745645ce013b348ef4d9f4ca7410/doc/constitution.md?plain=1#L96) says:
  > Disqualifications of candidates in an election requires supermajority among the currently serving SC members.
- While [this part](https://github.com/NixOS/org/blob/bd3ca5a88af0745645ce013b348ef4d9f4ca7410/doc/constitution.md?plain=1#L154) says:
  > [...], the SC can prevent a nominee from becoming a candidate by unanimity (among the currently serving non-running members of the SC) [...]

Looking into the public and private logs of the NCA, it's clear that we intended for it to be a supermajority among the currently serving SC members:
- 2024-08-30: In the [first constitution draft](https://discourse.nixos.org/t/nix-governance-constitution-draft-for-feedback/51373) it was consistently unanimity among non-running SC members.
- 2024-09-08: An issue was brought up while collecting feedback on the first draft and then [internally brought up](https://nixpkgs.zulipchat.com/#narrow/near/468622244)[^1]:

  > > Disqualifications of candidates in an election requires unanimity among the currently serving non-running members.
  >
  > What if there aren't any non-running members?
  > Or what if there's just one?

  Notably this can happen because arbitrarily many SC members can resign before an election.

[^1]: Link only accessible to NCA members

- 2024-09-09: The NCA had a meeting with all 7 members present, where we [discussed](https://github.com/nix-constitutional-assembly-2024/internal/blob/main/meetings/2024-09-09.md#httpsgithubcomnix-constitutional-assembly-2024internalpull94)[^1] ways of resolving this issue. We ended up agreeing on
  > Disqualifications of candidates in an election requires supermajority among the currently serving SC members.

  Some of the supporting reasons were:
  - [later inferred] At least the "non-running" clause has to be removed for it to be well-defined.
  - A reason this was [originally specified as a unanimity](https://github.com/nix-constitutional-assembly-2024/internal/pull/57)[^1] is because only at most 3-4 people could be "non-running", and a supermajority is the same as unanimity for 3 people.
  - Unanimity among a large groups almost never happens, supermajority should be enough for 7 people.
  - The decision to prevent somebody from running is similar to kicking somebody off the SC, which also needs a supermajority.

  The constitution draft was [correspondingly updated](https://github.com/NixOS/nix-constitutional-assembly/commit/f089b00b513b68babf9006ff72e6e6c1aab311ed), but apparently in only one of the two necessary places.

This commit resolves this ambiguity by also updating the other place to match what the NCA last agreed on.

This ambiguity had no impact so far, because we've only had the first election, during which nobody had the power to disqualify any candidates fulfilling the criteria.