### PR TITLE
rulesets/nixpkgs: disallow creation of new branches

### DIFF
--- a/rulesets/nixpkgs/no-creation-except-channel-updaters.json
+++ b/rulesets/nixpkgs/no-creation-except-channel-updaters.json
@@ -1,0 +1,29 @@
+{
+  "name": "no-creation-except-release-team",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/nixos-*",
+        "refs/heads/nixpkgs-*",
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3475569,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "never"
+}

--- a/rulesets/nixpkgs/no-creation-except-channel-updaters.json
+++ b/rulesets/nixpkgs/no-creation-except-channel-updaters.json
@@ -1,5 +1,6 @@
 {
-  "name": "no-creation-except-release-team",
+  "id": 6624203,
+  "name": "no-creation-except-channel-updaters",
   "target": "branch",
   "source_type": "Repository",
   "source": "NixOS/nixpkgs",
@@ -9,7 +10,7 @@
       "exclude": [],
       "include": [
         "refs/heads/nixos-*",
-        "refs/heads/nixpkgs-*",
+        "refs/heads/nixpkgs-*"
       ]
     }
   },
@@ -18,6 +19,8 @@
       "type": "creation"
     }
   ],
+  "created_at": "2025-07-10T22:35:49.878+02:00",
+  "updated_at": "2025-07-10T22:35:49.878+02:00",
   "bypass_actors": [
     {
       "actor_id": 3475569,

--- a/rulesets/nixpkgs/no-creation-except-release-team.json
+++ b/rulesets/nixpkgs/no-creation-except-release-team.json
@@ -1,4 +1,5 @@
 {
+  "id": 6624166,
   "name": "no-creation-except-release-team",
   "target": "branch",
   "source_type": "Repository",
@@ -9,7 +10,7 @@
       "exclude": [],
       "include": [
         "refs/heads/release-*",
-        "refs/heads/staging-*",
+        "refs/heads/staging-*"
       ]
     }
   },
@@ -18,6 +19,8 @@
       "type": "creation"
     }
   ],
+  "created_at": "2025-07-10T22:32:36.981+02:00",
+  "updated_at": "2025-07-10T22:32:36.981+02:00",
   "bypass_actors": [
     {
       "actor_id": 3620128,

--- a/rulesets/nixpkgs/no-creation-except-release-team.json
+++ b/rulesets/nixpkgs/no-creation-except-release-team.json
@@ -1,0 +1,29 @@
+{
+  "name": "no-creation-except-release-team",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/release-*",
+        "refs/heads/staging-*",
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3620128,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "never"
+}

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -7,9 +7,17 @@
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "exclude": [],
+      "exclude": [
+        "refs/heads/backport-*",
+        "refs/heads/nixos-*",
+        "refs/heads/nixpkgs-*",
+        "refs/heads/release-*",
+        "refs/heads/revert-**",
+        "refs/heads/staging-*",
+        "refs/heads/wip-*",
+      ],
       "include": [
-        "refs/heads/main"
+        "refs/heads/**"
       ]
     }
   },

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -14,10 +14,10 @@
         "refs/heads/release-*",
         "refs/heads/revert-**",
         "refs/heads/staging-*",
-        "refs/heads/wip-*",
+        "refs/heads/wip-*"
       ],
       "include": [
-        "refs/heads/**"
+        "~ALL"
       ]
     }
   },


### PR DESCRIPTION
This disallows the creation of new branches in the nixpkgs repo with the following exceptions:
- `backport-`, `revert-` and `wip-` branches can be created by anyone.
- `nixos-` and `nixpkgs-` branches can be created by the channel updaters.
- `release-` and `staging-` branches can be created by the release team.

This does not affect any existing branches, which we can fade out over time instead.

This is work towards #118, although I wouldn't close that issue with this, yet. There's more ideas in there, some of which I'd need to move to the nixpkgs repo's CI as well. But also the clarification of "development branches" for some other branch protection rules.