### PR TITLE
rulesets/nixpkgs: introduce required status checks

### DIFF
--- a/rulesets/nixpkgs/required-status-checks.json
+++ b/rulesets/nixpkgs/required-status-checks.json
@@ -1,4 +1,5 @@
 {
+  "id": 6624327,
   "name": "required-status-checks",
   "target": "branch",
   "source_type": "Repository",
@@ -11,7 +12,7 @@
         "~DEFAULT_BRANCH",
         "refs/heads/release*",
         "refs/heads/staging*",
-        "refs/heads/haskell-updates",
+        "refs/heads/haskell-updates"
       ]
     }
   },
@@ -30,6 +31,8 @@
       }
     }
   ],
+  "created_at": "2025-07-10T22:48:00.187+02:00",
+  "updated_at": "2025-07-10T22:48:00.187+02:00",
   "bypass_actors": [
     {
       "actor_id": 203427,
@@ -37,5 +40,5 @@
       "bypass_mode": "always"
     }
   ],
-  "current_user_can_bypass": "never"
+  "current_user_can_bypass": "always"
 }

--- a/rulesets/nixpkgs/required-status-checks.json
+++ b/rulesets/nixpkgs/required-status-checks.json
@@ -1,0 +1,41 @@
+{
+  "name": "required-status-checks",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release*",
+        "refs/heads/staging*",
+        "refs/heads/haskell-updates",
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "no PR failures",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 203427,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "never"
+}


### PR DESCRIPTION
This enables the "Required Status Checks" feature for Nixpkgs' development branches.

At this stage, all nixpkgs committers can bypass the checks. See discussion in #130.

Notes:
- I intentionally left out `python-updates` and `r-updates`, which both have "no-delete" rules, but not "no-force-push". Status of those branches is discussed in #118.
- The teams ID can be confirmed with: `gh api /orgs/NixOS/teams/nixpkgs-committers`.
- #130 also mentions a "allow reverts" step, but this can be done *after* enabling the ruleset, since all committers can bypass anyway.

cc @MattSturgeon