### PR TITLE
Reconcile difference in ruleset export

### DIFF
--- a/rulesets/nixpkgs/no-force-push.json
+++ b/rulesets/nixpkgs/no-force-push.json
@@ -11,10 +11,10 @@
       "include": [
         "~DEFAULT_BRANCH",
         "refs/heads/release*",
-        "refs/heads/staging*",
         "refs/heads/nixos-*",
         "refs/heads/nixpkgs-*",
-        "refs/heads/haskell-updates"
+        "refs/heads/haskell-updates",
+        "refs/heads/staging*"
       ]
     }
   },


### PR DESCRIPTION
The rulesets were never reexported after applying https://github.com/NixOS/org/pull/131