### PR TITLE
rulesets/nixpkgs: delete accidentally created protected branches

### DIFF
--- a/rulesets/nixpkgs/no-delete.json
+++ b/rulesets/nixpkgs/no-delete.json
@@ -7,7 +7,14 @@
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "exclude": [],
+      "exclude": [
+        "refs/heads/nixos-test-staging",
+        "refs/heads/nixos-test-staging-baseline",
+        "refs/heads/release-18.09-firefox64",
+        "refs/heads/staging-next-xdg-desktop-portal-gnome-dependency",
+        "refs/heads/staging-patchelf",
+        "refs/heads/staging-python"
+      ],
       "include": [
         "~DEFAULT_BRANCH",
         "refs/heads/release*",


### PR DESCRIPTION
These branches had been created with a protected prefix in the past - and thus accidentally became protected. This also meant that no pushes were possible eventually - and thus these branches were quickly abandoned.

This PR intends to add these temporarily to the ruleset as exceptions - to then delete the branches immediately. Thus, this PR doesn't need to actually be merged. Importing the ruleset, deleting the branches, and then reverting the ruleset to its previous state should be enough.

Now that #132 prevents the accidental creation of new cases, we can do this.