### PR TITLE
Init hetzner.md file to document Hetzner accounts and projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,3 +29,4 @@
 /doc/nixpkgs-committers.md @NickCao @jtojnar @winterqt
 /doc/calendar.md @edolstra @tomberek @fricklerhandwerk
 /doc/nixcon.md @NixOS/steering
+/doc/hetzner.md @NixOS/infra

--- a/doc/hetzner.md
+++ b/doc/hetzner.md
@@ -1,0 +1,14 @@
+# Hetzner
+
+We have multiple Hetzner Robot and Hetzner Cloud accounts/projects.
+
+## Hetzner Cloud
+
+### Nixpkgs Security Tracker project
+
+The [Nixpkgs Security Tracker](https://tracker.security.nixos.org/) runs in a
+Hetzner Cloud project named `nixpkgs-security-tracker` with ID `3668536`.
+
+The project members are:
+- foundation@nixos.org as an owner
+- nixos@dgrig.com (@erethon) as an admin


### PR DESCRIPTION
I believe we have multiple projects and accounts in Hetzner, but I don't know the details for them. This documents the one account I have admin access (`nixpkgs-security-tracker`).

Done as part of https://github.com/Nix-Security-WG/nix-security-tracker/issues/602