### PR TITLE
rulesets/nixpkgs: allow reverting r-ryantm branches via UI

### DIFF
--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -12,7 +12,8 @@
         "refs/heads/nixos-*",
         "refs/heads/nixpkgs-*",
         "refs/heads/release-*",
-        "refs/heads/revert-**",
+        "refs/heads/revert-*",
+        "refs/heads/revert-*/**",
         "refs/heads/staging-*",
         "refs/heads/wip-*"
       ],

--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -12,10 +12,10 @@
         "refs/heads/nixos-*",
         "refs/heads/nixpkgs-*",
         "refs/heads/release-*",
-        "refs/heads/revert-*",
-        "refs/heads/revert-*/**",
         "refs/heads/staging-*",
-        "refs/heads/wip-*"
+        "refs/heads/wip-*",
+        "refs/heads/revert-*",
+        "refs/heads/revert-*/**"
       ],
       "include": [
         "~ALL"


### PR DESCRIPTION
These branches contain a `/` as in `auto-update/re2`. While `**` is supposed to match `/`, the glob syntax is still not easy to get right.

Tested this in my fork, this works for both branches with `/` and without `/`.

Reported by @philiptaron in https://github.com/NixOS/nixpkgs/pull/420319#issuecomment-3079769010.

@infinisil can you fix this?