### PR TITLE
rulesets/nixpkgs: allow dependabot branch creation

### DIFF
--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -15,7 +15,8 @@
         "refs/heads/staging-*",
         "refs/heads/wip-*",
         "refs/heads/revert-*",
-        "refs/heads/revert-*/**"
+        "refs/heads/revert-*/**",
+        "refs/heads/dependabot/**"
       ],
       "include": [
         "~ALL"
@@ -28,7 +29,7 @@
     }
   ],
   "created_at": "2025-06-11T20:44:19.501+02:00",
-  "updated_at": "2025-06-11T20:44:19.501+02:00",
+  "updated_at": "2025-07-22T13:05:30.263+02:00",
   "bypass_actors": [],
   "current_user_can_bypass": "never"
 }


### PR DESCRIPTION
Dependabot can't create branches anymore to update github-actions: https://github.com/NixOS/nixpkgs/network/updates

Broke in #132.

I hope this fixes it, but the double star glob was confusing the last time, so let's see...