### PR TITLE
rulesets: add default branch protection for all repositories

### DIFF
--- a/rulesets/no-rewrite-history.json
+++ b/rulesets/no-rewrite-history.json
@@ -1,0 +1,31 @@
+{
+  "id": 8657816,
+  "name": "no-rewrite-history",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "NixOS",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    },
+    "repository_name": {
+      "exclude": [],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
This adds a default branch protection ruleset for *all* (existing and future) repositories in the NixOS org. It only targets the default branch and disallows deletion and force pushes.

This seems like a reasonable default and I doubt that any repositories depend on being able to do either of that. And *if* they do, it's doubtful, whether these repositories are in the right place in the NixOS org.

This needs to be imported on the *organization* level, via Settings -> Repository -> Rulesets.