### PR TITLE
rulesets/nixpkgs: fix branch creation rules

### DIFF
--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -15,8 +15,9 @@
         "refs/heads/staging-*",
         "refs/heads/wip-*",
         "refs/heads/revert-*",
-        "refs/heads/revert-*/**",
-        "refs/heads/dependabot/**"
+        "refs/heads/wip-*/**/*",
+        "refs/heads/revert-*/**/*",
+        "refs/heads/dependabot/**/*"
       ],
       "include": [
         "~ALL"
@@ -29,7 +30,7 @@
     }
   ],
   "created_at": "2025-06-11T20:44:19.501+02:00",
-  "updated_at": "2025-07-22T13:05:30.263+02:00",
+  "updated_at": "2025-08-11T16:26:43.654+02:00",
   "bypass_actors": [],
   "current_user_can_bypass": "never"
 }


### PR DESCRIPTION
Allowing any number of `/` needs the `**/*` syntax.

While at it with the default ruleset, I also fixed https://github.com/NixOS/org/pull/144#discussion_r2222216286. This time, I created these rules in my fork and ran various `gh api /repos/<org>/nixpkgs/rules/branches/....` request against it. This now works with any number of `/`.