### PR TITLE
rulesets/nixpkgs: add merge queue for lints on master

### DIFF
--- a/rulesets/nixpkgs/no-creation.json
+++ b/rulesets/nixpkgs/no-creation.json
@@ -17,7 +17,8 @@
         "refs/heads/revert-*",
         "refs/heads/wip-*/**/*",
         "refs/heads/revert-*/**/*",
-        "refs/heads/dependabot/**/*"
+        "refs/heads/dependabot/**/*",
+        "refs/heads/gh-readonly-queue/**/*"
       ],
       "include": [
         "~ALL"

--- a/rulesets/nixpkgs/require-merge-queue.json
+++ b/rulesets/nixpkgs/require-merge-queue.json
@@ -1,0 +1,36 @@
+{
+  "name": "require-merge-queue",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "MERGE",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 5,
+        "grouping_strategy": "ALLGREEN",
+        "check_response_timeout_minutes": 60
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 203427,
+      "actor_type": "Team",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}


### PR DESCRIPTION
This requires https://github.com/NixOS/nixpkgs/pull/431146 and enables a very basic merge queue for the master branch in nixpkgs. At this stage, this only runs the "lint" group of checks: treefmt, nixpkgs-vet and the parse check. We should do this right now, because the recent nixfmt 1.0.0 update can easily cause nixfmt regressions after merging a seemingly OK PR - where nixfmt ran before the update, but the would need to run again afterwards.

We're not including all of the other checks, yet, because any change included here means it can't be bypassed anymore. We'll need to investigate whether we might still need to be able to do this later on, for now I added the CI team as by-passers as a safety net

This includes the commit from #146, to avoid merge conflicts. Also, we should probably wait on that to be merged anyway, because it currently causes dependabot to not do updates. This means we're not running Nix 2.30 in GHA, yet, which means we are still subject to random nixpkgs-vet failures. These go away after rerunning the job, but would still kick the PR out of the queue at first. So we might just as well wait for this update to be in.

cc @NixOS/nixpkgs-ci 