### PR TITLE
Give @mweinelt access to the Google calendar

### DIFF
--- a/doc/calendar.md
+++ b/doc/calendar.md
@@ -12,3 +12,4 @@ These Google accounts can only make changes to events:
 - silvan.mosberger@moduscreate.com (@infinisil)
 - jeremyfleischman@gmail.com (@jfly)
 - daniel.n.baker@gmail.com (@djacu)
+- @mweinelt


### PR DESCRIPTION
As part of the infra team, @mweinelt should be able to update the infra teams meeting in the calendar.

Whoever merges and implements this PR (@edolstra, @tomberek or @fricklerhandwerk) I'll PM the Google account.