### PR TITLE
rulesets/nixpkgs: disallow squash/rebase merges on development branches

### DIFF
--- a/rulesets/nixpkgs/require-merge-method.json
+++ b/rulesets/nixpkgs/require-merge-method.json
@@ -1,0 +1,41 @@
+{
+  "name": "require-merge-method",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release*",
+        "refs/heads/staging*",
+        "refs/heads/haskell-updates"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 203427,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1075715,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "always"
+}


### PR DESCRIPTION
With the [introduction of Merge Queues](https://github.com/NixOS/org/pull/149), the only merge method on those branches will be "merge" as configured for the Merge Queue. By disallowing the other merge methods on development branches without merge queue, we [achieve consistency without relying on contributor documentation](https://github.com/NixOS/nixpkgs/pull/438686#discussion_r2312393859).

Resolves #135