### PR TITLE
rulesets/nixpkgs: add merge queue to release-25.05

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue.json
+++ b/rulesets/nixpkgs/require-merge-queue.json
@@ -8,7 +8,8 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "~DEFAULT_BRANCH"
+        "~DEFAULT_BRANCH",
+        "release-25.05"
       ]
     }
   },


### PR DESCRIPTION
Now that the merge queue works fine on master, we can also enable it for the release branch.

cc @NixOS/nixpkgs-ci 