### PR TITLE
rulesets/nixpkgs: switch merge queue to "headgreen" strategy

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue.json
+++ b/rulesets/nixpkgs/require-merge-queue.json
@@ -22,8 +22,8 @@
         "min_entries_to_merge": 1,
         "max_entries_to_merge": 5,
         "min_entries_to_merge_wait_minutes": 5,
-        "grouping_strategy": "ALLGREEN",
-        "check_response_timeout_minutes": 60
+        "grouping_strategy": "HEADGREEN",
+        "check_response_timeout_minutes": 20
       }
     }
   ],


### PR DESCRIPTION
The `ALLGREEN` setting corresponds to "Require all queue entries to pass required checks". `HEADGREEN` is the opposite, when disabling that checkbox, which then behaves like this:

> only the commit at the head of the merge group, i.e. the commit
> containing changes from all of the PRs in the group, must pass its
> required checks to merge.

This should fix an odd scheduling behavior we're seeing for a few days now: With a reasonable number of jobs queued, GitHub will sometimes just forget to schedule jobs for a merge queue item. These will then wait for an hour for the status check to timeout, be kicked out of the queue and all other jobs run again.

We don't really need to do that, though: We already require status checks for each PR individually, thus there is a *very low chance* of introducing introducing a commit that:
- Passes CI in the PR, and
- Fails CI in the Merge Queue, and
- Is fixed by a random PR queue up behind it.

While at it, also reduce the timeout from 60 minutes to 20 minutes, because we'll certainly not need more time for any merge to master, even if we had the Eval and Build workflows running (which is not even the case, yet).

---

The "broken" state of the merge queue looks like this:

<img width="898" height="374" alt="2025-09-21T15:14:32,696351609+02:00" src="https://github.com/user-attachments/assets/bc6c5a62-ffb6-4b14-9720-c596520860c7" />

Note how the first item has been queued for more than 20 minutes and still didn't post a result. Going into the Actions tab, we can also see that GitHub never scheduled a run for this commit...

cc @NixOS/nixpkgs-ci 