### PR TITLE
Add nixpkgs-core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /default.nix @NixOS/org
 /shell.nix @NixOS/org
 /rulesets @NixOS/org
+/rulesets/nixpkgs @NixOS/nixpkgs-core
 
 /doc/org-repo.md @NixOS/steering
 /doc/discourse.md @NixOS/steering @mweinelt @picnoir @lassulus @jtojnar @ctheune @dpausp
@@ -19,14 +20,15 @@
 /doc/github-org-owners.md @NixOS/steering
 /doc/matrix.md @NixOS/steering
 /doc/moderation.md @NixOS/steering
-/doc/nixos-releases.md @NixOS/steering
+/doc/nixos-releases.md @NixOS/nixpkgs-core
 /doc/resources.md @NixOS/steering
 /doc/mail.md @NixOS/infra
 /doc/governance.md @NixOS/steering
 /doc/values.md @NixOS/steering
 /doc/vault.md @Mic92 @mweinelt @zimbatm
 /doc/constitution.md @NixOS/steering
-/doc/nixpkgs-committers.md @NickCao @jtojnar @winterqt
+/doc/nixpkgs-core.md @NixOS/nixpkgs-core
+/doc/nixpkgs-committers.md @NickCao @jtojnar @winterqt @NixOS/nixpkgs-core
 /doc/calendar.md @edolstra @tomberek @fricklerhandwerk
 /doc/nixcon.md @NixOS/steering
 /doc/hetzner.md @NixOS/infra

--- a/doc/github.md
+++ b/doc/github.md
@@ -20,6 +20,8 @@ Furthermore, every [Nixpkgs maintainer](https://github.com/NixOS/nixpkgs/tree/ma
 Being a Nixpkgs maintainer doesn't grant any permissions by itself.
 They can however make use of the [Nixpkgs merge bot](https://github.com/NixOS/nixpkgs-merge-bot) in certain cases.
 
+The [Nixpkgs core team](./nixpkgs-core.md) controls this repository.
+
 ### [nix](https://github.com/NixOS/nix)
 
 The Nix language and CLI implementation.

--- a/doc/governance.md
+++ b/doc/governance.md
@@ -26,6 +26,8 @@ To add a new team to this list, open a PR on the [nixos-homepage repository](htt
 
 ### Nixpkgs
 
+The [Nixpkgs core team](./nixpkgs-core.md) governs Nixpkgs and its teams.
+
 More Nixpkgs-specific teams are declared in the [`maintainers/team-list.nix` file](https://github.com/NixOS/nixpkgs/blob/master/maintainers/team-list.nix), which can be programmatically accessed using `lib.teams`.
 
 To add a new team to this list, open a PR to change it.

--- a/doc/nixpkgs-core.md
+++ b/doc/nixpkgs-core.md
@@ -1,0 +1,17 @@
+## Nixpkgs core team
+
+The Nixpkgs core team provides leadership for and has authority over Nixpkgs.
+
+The team has the following members:
+<!-- Also keep this in sync with the members of @NixOS/nixpkgs-core! -->
+- [@alyssais](https://github.com/alyssais)
+- [@emilazy](https://github.com/emilazy)
+- [@K900](https://github.com/K900)
+- [@wolfgangwalther](https://github.com/wolfgangwalther)
+
+## How to contact the team
+
+You can reach the Nixpkgs core team:
+- on [Discourse](https://discourse.nixos.org/g/nixpkgs-core)
+- by Email at nixpkgs-core@nixos.org
+- on GitHub, by pinging [@NixOS/nixpkgs-core](https://github.com/orgs/NixOS/teams/nixpkgs-core)


### PR DESCRIPTION
This documents the new [Nixpkgs core team](https://discourse.nixos.org/t/establishing-the-nixpkgs-core-team/69743) and adds it as codeowner of the respective files (the team will need write access to this repo as well, see below).

The team page is very basic for now, just providing our contact details to get these spread quickly. We will later extend this with more information about how we intend to work etc.

We also identified the list of repos in the NixOS org that belong to the scope of Nixpkgs (see list below). By adding them to the GitHub team this clarifies the scope of our mandate transparently.

We intend to manage the rulesets for these repos ourselves to speed up iteration for the CI team and take load off of the org team.

Besides merging this PR, the following needs to be done by @NixOS/org:
- [x] Give @NixOS/nixpkgs-core write privileges in https://github.com/NixOS/org
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/cabal2nix
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/jailbreak-cabal
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/nixos-hardware
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/nixpkgs
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/nixpkgs-committers
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/nixpkgs-merge-bot
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/nixpkgs-vet
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/ofborg
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/ofborg-viewer
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/release-wiki
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/reproducible.nixos.org
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/rfc39
- [x] Give @NixOS/nixpkgs-core admin privileges in https://github.com/NixOS/rfc39-record
