### PR TITLE
Nixpkgs committers: Refer to new repo and switch to PR nominations

### DIFF
--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -1,7 +1,8 @@
 # Nixpkgs committers
 
 There are [200 Nixpkgs committers](https://github.com/NixOS/nixpkgs-committers/tree/main/members) with access to merge any PR.
-To become a Nixpkgs committer, you can apply [in this issue](https://github.com/NixOS/nixpkgs/issues/321665).
+You can nominate yourself or another contributor to become a Nixpkgs committer.
+This should be done by following [these instructions](https://github.com/NixOS/nixpkgs-committers?tab=readme-ov-file#nominations).
 
 The [Nixpkgs committer delegation team](#team) is given the responsibility and authority of changing the list of [Nixpkgs committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers).
 

--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -14,7 +14,7 @@ Nixpkgs committer delegation team consists of these people:
 - [@jtojnar](https://github.com/jtojnar) ([Matrix](https://matrix.to/#/@jtojnar:matrix.org), [Discourse](https://discourse.nixos.org/u/jtojnar))
 - [@winterqt](https://github.com/winterqt) ([Matrix](https://matrix.to/#/@winter:catgirl.cloud), [Discourse](https://discourse.nixos.org/u/winter))
 
-They can be contacted either individually, or through a [group message on Discourse](https://discourse.nixos.org/g/nixpkgs-nominations).
+They can be contacted either individually, through a [group message on Discourse](https://discourse.nixos.org/g/nixpkgs-nominations), or by pinging the GitHub team [@NixOS/commit-bit-delegation](https://github.com/orgs/NixOS/teams/commit-bit-delegation/).
 
 ## Process
 - The process must be publicly documented (this document)

--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -1,6 +1,6 @@
 # Nixpkgs committers
 
-There are over 200 Nixpkgs committers with access to merge any PR.
+There are [200 Nixpkgs committers](https://github.com/NixOS/nixpkgs-committers/tree/main/members) with access to merge any PR.
 To become a Nixpkgs committer, you can apply [in this issue](https://github.com/NixOS/nixpkgs/issues/321665).
 
 The [Nixpkgs committer delegation team](#team) is given the responsibility and authority of changing the list of [Nixpkgs committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers).


### PR DESCRIPTION
Relates to https://github.com/NixOS/nixpkgs-committers/issues/62

Depends on https://github.com/NixOS/nixpkgs-committers/pull/34, which should be approved by all @NixOS/commit-bit-delegation members to satisfy the process.