### PR TITLE
constitution: count vacant seats when voting full reelection

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -108,7 +108,7 @@ Deciding that an amendment is not substantial can be done by unanimity among a f
 
 #### Ordinary decisions
 
-Everything within the authority of SC that doesn't require an extraordinary decision can be decided with a simple majority (more than 50%) of a full SC (vacant seats count as abstaining, except when voting for reelection).
+Everything within the authority of SC that doesn't require an extraordinary decision can be decided with a simple majority (more than 50%) of a full SC (vacant seats count as abstaining, [except when voting for reelection](#full-reelections)).
 
 An exception to that is when there is when the [conflict of interest balance](#conflict-of-interest-coi-balance) condition is suspected to be violated.
 In that case, all non-involved currently serving SC members will have a simple majority decision over whether there is a violation.

--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -108,7 +108,7 @@ Deciding that an amendment is not substantial can be done by unanimity among a f
 
 #### Ordinary decisions
 
-Everything within the authority of SC that doesn't require an extraordinary decision can be decided with a simple majority (more than 50%) of a full SC (vacant seats count as abstaining).
+Everything within the authority of SC that doesn't require an extraordinary decision can be decided with a simple majority (more than 50%) of a full SC (vacant seats count as abstaining, except when voting for reelection).
 
 An exception to that is when there is when the [conflict of interest balance](#conflict-of-interest-coi-balance) condition is suspected to be violated.
 In that case, all non-involved currently serving SC members will have a simple majority decision over whether there is a violation.
@@ -205,6 +205,7 @@ A committee member elected in a special election will serve out the remainder of
 
 A simple majority within the SC may call a reelection of the entire SC based on perceived loss of confidence.
 In this case, it also has to be decided whether this election is considered a special election for the remainders of all the corresponding terms, or an initial election for full 2-year terms for half of the seats rounded up and 1-year half-terms for the remaining seats.
+Vacant seats vote in favour of reelection, and between initial election and special election they count towards special election.
 
 ### Removal for conduct
 


### PR DESCRIPTION
The way the constitution is currently written, the SC can entirely deadlock, if one seat is vacant and 50% of the remaining SC are calling for no confidence, while the other 50% disagree.

The SC can neither be fully re-elected, nor make any other decisions with simple majority.

<details>
<summary>I also considered a few alternatives, which I have not taken for various reasons.</summary>

## 1. Flip to "vote of confidence"

Change the above to:

> Any SC member may call for a vote of confidence. If this vote does not pass with a simple majority, the entire SC will be reelected based on perceived loss of confidence.

Pro:
- Resolves the deadlock.

Contra:
- Creates a "pending" state for regular case without vacant seats, probably would need a clear deadline for votes.
- Unclear what happens with special vs initial election.


## 2. Pass on ties

Change the above to:

> A simple majority within the SC may call a reelection of the entire SC based on perceived loss of confidence. A tie counts as majority.

Pro:

Contra:
- Doesn't solve the deadlock, because 4 votes are needed anyway, so *there are no ties*.
- Unclear what happens with special vs initial election.


## 3. Count vacant seats as reelection only

Change the above to:

> A simple majority within the SC may call a reelection of the entire SC based on perceived loss of confidence. Vacant seats count as voting for reelection.

Pro:
- Resolves the deadlock.

Contra:
- Unclear what happens with special vs initial election.
</details>

I thank @7c6f434c for helping with the wording here.