### PR TITLE
rulesets/nixpkgs: enable merge queue on secondary development branches

### DIFF
--- a/rulesets/export.bash
+++ b/rulesets/export.bash
@@ -6,5 +6,5 @@ REPO="${1:?Please pass the repository name as the only argument.}"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-gh api "/repos/NixOS/$REPO/rulesets" --jq '.[] | "\(._links.self.href) \(.name)"' \
+gh api "/repos/NixOS/$REPO/rulesets" --jq '.[] | select(.source_type == "Repository") | "\(._links.self.href) \(.name)"' \
 	| xargs -n2 sh -c "gh api \$0 | jq 'del(.node_id, ._links)' > $REPO/\$1.json"

--- a/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
+++ b/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
@@ -1,0 +1,49 @@
+{
+  "id": 8822191,
+  "name": "require-merge-queue-except-periodic-merges",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NixOS/nixpkgs",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/haskell-updates",
+        "refs/heads/staging",
+        "refs/heads/staging-next",
+        "refs/heads/staging-25.05",
+        "refs/heads/staging-next-25.05"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "MERGE",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 5,
+        "grouping_strategy": "HEADGREEN",
+        "check_response_timeout_minutes": 20
+      }
+    }
+  ],
+  "created_at": "2025-10-12T12:47:50.629+02:00",
+  "updated_at": "2025-10-12T12:47:50.705+02:00",
+  "bypass_actors": [
+    {
+      "actor_id": 203427,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1075715,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "current_user_can_bypass": "always"
+}


### PR DESCRIPTION
This enables Merge Queues on secondary development branches like staging and haskell-updates as well.

These branches still need to be pushed to manually for the periodic merges, both automated by CI and manually by committers. Compared to the [ruleset for merge queues on the primary development branches](https://github.com/NixOS/org/blob/main/rulesets/nixpkgs/require-merge-queue.json), this `always` allows bypassing. Since the number of merges on these branches is much lower, an occasional bypassing of the queue for the periodic merges is not a problem, at least resource-wise.

We will still want to eventually implement a [PR-based workflow for periodic merges](https://github.com/NixOS/nixpkgs/issues/424345) to make sure these never break the branch.

Although not the primary motivation, this will also resolve #135.

cc @NixOS/nixpkgs-ci