### PR TITLE
retire value stable evolution

### DIFF
--- a/doc/values.md
+++ b/doc/values.md
@@ -59,13 +59,3 @@ We build trust primarily by working together on Nix projects.
 We are a global community, and disseminating information and maintaining processes can be difficult. We are also a large project with a lot of hard and repetitive work. Therefore, we value automation over toil, while recognizing that not all toil can be automated. Automation reduces toil, but people are still accountable. Adding new toil needs a very strong justification.
 
 We build automation and processes that make the best use of our contributors' limited time and energy.
-
-### Stable evolution over stagnation or chaos
-
-Openness to new ideas and evolution is part of what made Nix great. We continue to foster that evolution while encouraging development of re-usable building blocks and well-defined, stable interfaces.
-
-We value experimenting with designs and concepts, and folding successful experiments back into continuous improvement for stable components.
-
-The larger the impact an action has, the more care and discussion is warranted before taking the action.
-
-Our leaders have a duty to find, support, and promote new contributors — and eventually step aside for new leaders.


### PR DESCRIPTION
One of the values we inherited from the interim Nix constitutional assembly is '[stable evolution over stagnation or chaos](https://nixos.org/values/#community-values-stability)'.

This value has since been used to argue against:

- [accountability](https://discourse.nixos.org/t/sc-meeting-2025-10-08-17-00-utc/70609) (why we even wanted elected representatives)
- [proportional representation](https://github.com/NixOS/org/pull/199#issuecomment-3506958459) (characterized as [of utmost importance](https://github.com/NixOS/org/pull/199#issuecomment-3506788693))
- (as per above) [protecting from destabilizing take-overs](https://discourse.nixos.org/t/proportionality-and-the-staggered-terms-in-sc/70563) (how was the value even intended?)

To be clear, if on a technical decision we used stability as a tiebreaker — then I get it.

When the community indicated the board last year seemed out of touch, the board opted to listen and step aside to make room for elected representatives.
If this value, however its intent, ends up functioning as it has though, I call that a regression, and propose reverting it.
