### PR TITLE
Change amendments to the values to require an SC supermajority

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -95,7 +95,7 @@ Furthermore, the SC decides on the Election Committee (EC) with a 2/3 supermajor
 
 Disqualifications of candidates in an election requires supermajority among the currently serving SC members.
 
-Substantial amendments to the Nix Community Values require 90% agreement in a poll among eligible voters. Deciding that an amendment is not substantial can be done by unanimity among a full SC.
+Substantial amendments to the Nix Community Values requires a supermajority of a full SC.
 
 #### Ordinary decisions
 


### PR DESCRIPTION
There are two main rationales behind this change:

- It doesn't make sense for amendments to the values to require a higher threshold than amendments to the Constitution, given that the Constitution governs amendments to the values

  Whether or not people believe that this Constitutional amendment *should* pass, the fact that this amendment *could* pass with a 5/7 vote highlights why the 90% requirement does not actually exist in practice.

- The first draft of the values was not approved by 90% of the community

  It seems weird to privilege the first draft of the values when it never had to clear the same bar as amendments to the values.