### PR TITLE
Make the NCV amendment requirement self-referential

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -95,7 +95,9 @@ Furthermore, the SC decides on the Election Committee (EC) with a 2/3 supermajor
 
 Disqualifications of candidates in an election requires supermajority among the currently serving SC members.
 
-Substantial amendments to the Nix Community Values require 90% agreement in a poll among eligible voters. Deciding that an amendment is not substantial can be done by unanimity among a full SC.
+Substantial amendments to the Nix Community Values require 90% agreement in a poll among eligible voters.
+Substantial amendments to this paragraph of the constitution carry the same requirement, in addition to any other constitutional requirements for making that change.
+Deciding that an amendment of either document is not substantial can be done by unanimity among a full SC.
 
 #### Ordinary decisions
 


### PR DESCRIPTION
If for whatever reason the requirement difference between ‘doing the thing’ and ‘changing the rules that restrict doing the thing’ is seen as an inconsistency or weakness to be exploited, this is the natural way to close the loophole while preserving the original intent.

This is, of course, an alternative to #202, though I'm not sure either amendment is really needed.