### PR TITLE
xrefcheck: Only check local links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: serokell/xrefcheck-action@v1
       with:
-        xrefcheck-args: "--root untrusted-pr"
+        xrefcheck-args: "--root untrusted-pr --mode local-only"
 
   codeowners:
     name: Validate codeowners


### PR DESCRIPTION
We get frequent failures due to server problems when checking external links