### PR TITLE
have vacant seats slightly prefer full reelection on no-confidence

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -205,7 +205,7 @@ A committee member elected in a special election will serve out the remainder of
 
 A simple majority within the SC may call a reelection of the entire SC based on perceived loss of confidence.
 In this case, it also has to be decided whether this election is considered a special election for the remainders of all the corresponding terms, or an initial election for full 2-year terms for half of the seats rounded up and 1-year half-terms for the remaining seats.
-Vacant seats vote in favour of reelection, and between initial election and special election they count towards special election.
+Vacant seats vote in favour of reelection, and between initial election and special election, they count towards an initial election in case a tiebreaker is needed, otherwise abstaining.
 
 ### Removal for conduct
 


### PR DESCRIPTION
This changes the effective voting preference of vacant SC seats in the event the SC has determined no-confidence, to vote toward full reelection in case a tiebreaker is needed.

I think this modest change:

- better matches the spirit of having such seats favor reelection in the first place (c.f. https://github.com/NixOS/SC-election-2025/issues/472);
- better conforms to proportional representation than (the more majoritarian) special elections would;
- better incentivizes the SC to prevent seats from going (or staying) vacant.

Builds upon #181 to implement my earlier [suggestion](https://github.com/NixOS/org/pull/181#pullrequestreview-3303529739) to this extent.
