### PR TITLE
rulesets/nixpkgs: enable merge queue for staging-25.11

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
+++ b/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
@@ -14,7 +14,9 @@
         "refs/heads/staging-next",
         "refs/heads/staging-25.05",
         "refs/heads/staging-next-25.05",
-        "refs/heads/staging-nixos"
+        "refs/heads/staging-nixos",
+        "refs/heads/staging-next-25.11",
+        "refs/heads/staging-25.11"
       ]
     }
   },

--- a/rulesets/nixpkgs/require-pull-request-except-release-team.json
+++ b/rulesets/nixpkgs/require-pull-request-except-release-team.json
@@ -20,6 +20,7 @@
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,


### PR DESCRIPTION
Part of the staging branch-off in https://github.com/NixOS/nixpkgs/pull/461526.

I already enabled the merge queue in the ruleset, this is just the export for documentation.