### PR TITLE
specify that the SC votes on confidence over non-confidence

### DIFF
--- a/doc/constitution.md
+++ b/doc/constitution.md
@@ -203,9 +203,9 @@ A committee member elected in a special election will serve out the remainder of
 
 #### Full Reelections
 
-A simple majority within the SC may call a reelection of the entire SC based on perceived loss of confidence.
+The SC may call a reelection of the SC by failing to secure the votes required to pass a vote of confidence.
 In this case, it also has to be decided whether this election is considered a special election for the remainders of all the corresponding terms, or an initial election for full 2-year terms for half of the seats rounded up and 1-year half-terms for the remaining seats.
-Vacant seats vote in favour of reelection, and between initial election and special election they count towards special election.
+Vacant seats vote against in the vote of confidence, and between initial election and special election they count towards special election.
 
 ### Removal for conduct
 


### PR DESCRIPTION
Adjusts the constitution phrasing to specify that the SC votes on confidence over non-confidence.

This on the one hands makes explicit how to handle this, while at the same time implementing the suggestion at https://github.com/NixOS/SC-election-2025/issues/472.
In practice, this means that the case of a tied vote will trigger a reelection, heightening the required threshold of internal confidence among SC members.

I attempted to phrase this to address concerns raised at #181 regarding risks of a pending state, although I imagine others might come up with better ideas on the phrasing.
