### PR TITLE
rulesets/nixpkgs: allow release team to always bypass merge-queue

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue.json
+++ b/rulesets/nixpkgs/require-merge-queue.json
@@ -34,6 +34,11 @@
       "actor_id": 203427,
       "actor_type": "Team",
       "bypass_mode": "pull_request"
+    },
+    {
+      "actor_id": 3620128,
+      "actor_type": "Team",
+      "bypass_mode": "always"
     }
   ],
   "current_user_can_bypass": "pull_requests_only"


### PR DESCRIPTION
They need to push to master as part of the release process.

cc @NixOS/nixos-release-managers 

(already implemented, will merge later once the release is done and no further changes were required)