### PR TITLE
nixpkgs-committers: hand over to the Nixpkgs core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 /doc/vault.md @Mic92 @mweinelt @zimbatm
 /doc/constitution.md @NixOS/steering
 /doc/nixpkgs-core.md @NixOS/nixpkgs-core
-/doc/nixpkgs-committers.md @NickCao @jtojnar @winterqt @NixOS/nixpkgs-core
+/doc/nixpkgs-committers.md @NixOS/nixpkgs-core
 /doc/calendar.md @edolstra @tomberek @fricklerhandwerk
 /doc/nixcon.md @NixOS/steering
 /doc/hetzner.md @NixOS/infra

--- a/doc/github.md
+++ b/doc/github.md
@@ -13,7 +13,7 @@ There are many repositories, but these are some of the most important ones.
 
 The Nix package collection and NixOS.
 
-Over 200 people have commit access, which is managed by the [Nixpkgs committer delegation team](./nixpkgs-committers.md).
+Over 200 people have commit access, which is managed by the [Nixpkgs core team](./nixpkgs-committers.md).
 
 Furthermore, every [Nixpkgs maintainer](https://github.com/NixOS/nixpkgs/tree/master/maintainers) is part of the organisation, such that they can be requested as a reviewer.
 

--- a/doc/nixpkgs-committers.md
+++ b/doc/nixpkgs-committers.md
@@ -4,17 +4,7 @@ There are [200 Nixpkgs committers](https://github.com/NixOS/nixpkgs-committers/t
 You can nominate yourself or another contributor to become a Nixpkgs committer.
 This should be done by following [these instructions](https://github.com/NixOS/nixpkgs-committers?tab=readme-ov-file#nominations).
 
-The [Nixpkgs committer delegation team](#team) is given the responsibility and authority of changing the list of [Nixpkgs committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers).
-
-## Team
-
-Nixpkgs committer delegation team consists of these people:
-<!-- Keep this list in sync with the codeowners of this file! -->
-- [@NickCao](https://github.com/NickCao) ([Matrix](https://matrix.to/#/@nickcao:nichi.co), [Discourse](https://discourse.nixos.org/u/nickcao))
-- [@jtojnar](https://github.com/jtojnar) ([Matrix](https://matrix.to/#/@jtojnar:matrix.org), [Discourse](https://discourse.nixos.org/u/jtojnar))
-- [@winterqt](https://github.com/winterqt) ([Matrix](https://matrix.to/#/@winter:catgirl.cloud), [Discourse](https://discourse.nixos.org/u/winter))
-
-They can be contacted either individually, through a [group message on Discourse](https://discourse.nixos.org/g/nixpkgs-nominations), or by pinging the GitHub team [@NixOS/commit-bit-delegation](https://github.com/orgs/NixOS/teams/commit-bit-delegation/).
+The [Nixpkgs core team](./nixpkgs-core.md) currently fills the role of the Nixpkgs committer delegation team and is given the responsibility and authority of changing the list of [Nixpkgs committers](https://github.com/orgs/NixOS/teams/nixpkgs-committers).
 
 ## Process
 - The process must be publicly documented (this document)


### PR DESCRIPTION
Per discussion with the current Nixpkgs committer delegation team about potential reforms for the commit bit process, they currently have insufficient time to work through applications and are happy for the Nixpkgs core team to take over. We’ve decided it’s best to step in to clear the backlog with the current process, without blocking on any further changes for now.

We’ll need an org owner to make the following changes:

* Replace @jtojnar and @NickCao with @alyssais, @emilazy, and @wolfgangwalther as maintainers of the [`@NixOS/nixpkgs-committers`] team.
  
* Replace @Mic92, @jtojnar, and @NickCao with @alyssais, @emilazy, and @wolfgangwalther as maintainers of the [`@NixOS/retired-nixpkgs-contributors`] team.

* Delete the [`@NixOS/commit-bit-delegation`] team as now redundant to @NixOS/nixpkgs-core.

[`@NixOS/nixpkgs-committers`]: <https://github.com/orgs/NixOS/teams/nixpkgs-committers>
[`@NixOS/retired-nixpkgs-contributors`]: <https://github.com/orgs/NixOS/teams/retired-nixpkgs-contributors>
[`@NixOS/commit-bit-delegation`]: <https://github.com/orgs/NixOS/teams/commit-bit-delegation>