### PR TITLE
Change calendar owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,6 @@
 /doc/constitution.md @NixOS/steering
 /doc/nixpkgs-core.md @NixOS/nixpkgs-core
 /doc/nixpkgs-committers.md @NixOS/nixpkgs-core
-/doc/calendar.md @edolstra @tomberek @fricklerhandwerk @cafkafk
+/doc/calendar.md @tomberek @cafkafk @infinisil
 /doc/nixcon.md @NixOS/steering
 /doc/hetzner.md @NixOS/infra

--- a/doc/calendar.md
+++ b/doc/calendar.md
@@ -4,13 +4,11 @@ There is [this official Google Calendar](https://calendar.google.com/calendar/u/
 
 These Google accounts have access to manage permissions (and make changes to events):
 <!-- Keep this list in sync with the codeowners of this file! -->
-- edolstra@gmail.com (@edolstra)
 - tomberek@gmail.com (@tomberek)
-- valentin.gagarin@gmail.com (@fricklerhandwerk)
 - cafkafk.nixos@gmail.com (@cafkafk)
+- silvan.mosberger@moduscreate.com (@infinisil)
 
 These Google accounts can only make changes to events:
-- silvan.mosberger@moduscreate.com (@infinisil)
 - jeremyfleischman@gmail.com (@jfly)
 - daniel.n.baker@gmail.com (@djacu)
 - @mweinelt


### PR DESCRIPTION
Remove @edolstra and @fricklerhandwerk, don't think they're very actively maintaining it.

Add @infinisil as board representative