### PR TITLE
nixpkgs-core: remove wolfgangwalther

### DIFF
--- a/doc/nixpkgs-core.md
+++ b/doc/nixpkgs-core.md
@@ -6,7 +6,6 @@ The team has the following members:
 <!-- Also keep this in sync with the members of @NixOS/nixpkgs-core! -->
 - [@alyssais](https://github.com/alyssais)
 - [@emilazy](https://github.com/emilazy)
-- [@wolfgangwalther](https://github.com/wolfgangwalther)
 
 ## Procedures
 


### PR DESCRIPTION
Stepping down from the core team. This is something that should have happened right after the election already - I lost the fun of working on Nixpkgs for others in the events leading up to the election and the election itself. Good luck everyone.