### PR TITLE
Give fricklerhandwerk access to Hetzner cloud

### DIFF
--- a/doc/hetzner.md
+++ b/doc/hetzner.md
@@ -12,3 +12,4 @@ Hetzner Cloud project named `nixpkgs-security-tracker` with ID `3668536`.
 The project members are:
 - foundation@nixos.org as an owner
 - nixos@dgrig.com (@erethon) as an admin
+- valentin.gagarin@tweag.io (@fricklerhandwerk) as an admin


### PR DESCRIPTION
Someone with owner access needs to click buttons, maybe @infinisil?

I need this to manage the server for https://tracker-staging.security.nixos.org