### PR TITLE
hetzner: remove JulienMalka from nixos-wiki project

### DIFF
--- a/doc/hetzner.md
+++ b/doc/hetzner.md
@@ -26,7 +26,6 @@ Project members:
 The official wiki instance at [https://wiki.nixos.org].
 
 Project members:
-- [@JulienMalka](https://github.com/JulienMalka) admin
 - [@lassulus](https://github.com/lassulus) admin
 - [@Mic92](https://github.com/Mic92) admin
 - [@vcunat](https://github.com/vcunat) admin


### PR DESCRIPTION
Julian expressed he no longer wants to help administrating the wiki. His access has already been revoked from the Hetzner project.

context: https://github.com/NixOS/org/pull/234