### PR TITLE
Add freescout workflows module

### DIFF
--- a/doc/freescout.md
+++ b/doc/freescout.md
@@ -8,7 +8,7 @@ You can request a shared inbox for your team, or changes to an existing inbox by
 
 For a new shared inbox, make sure to include:
 - Team name (will be used in email footer):
-- Email address: <email-handle>@nixos.org
+- Email address: \<email-handle\>@nixos.org
 
 <details><summary>@infinisil perform these steps to set up a new shared inbox:</summary>
 
@@ -99,5 +99,6 @@ The following modules are currently installed:
 - [Extended Editor](https://freescout.net/module/extended-editor/)
 - [Teams](https://freescout.net/module/teams/)
 - [Email Commands](https://freescout.net/module/email-commands/)
+- [Workflows](https://freescout.net/module/workflows/)
 
 Feel free to request additional modules by adding it to the above list and opening a PR.


### PR DESCRIPTION
Unfortunately only admins (and I'm the only one) can configure workflows right now. There's an option to allow any user to manage them, but it can't be changed due to https://cyberchaos.dev/e1mo/freescout-nix-flake/-/issues/3. And while we can adjust settings with Nix, I don't know the environment variable used by the workflows module to configure this permission.