### PR TITLE
Revise NixCon 2026 sponsorship details (only organisers version)

### DIFF
--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -13,57 +13,44 @@ The conference has previously been held in these locations:
 - 2023: Darmstadt (Germany), https://2023.nixcon.org/
 - 2024: Berlin (Germany), https://2024.nixcon.org/
 - 2025: Rapperswil-Jona (Switzerland), https://2025.nixcon.org/
+- 2026: Kraków (Poland), https://2026.nixcon.org/
 
 ## NixCon 2026
 
-NixCon 2026 is likely to happen but no team has yet been assembled to make that a reality. [Contact the steering committee](mailto:steering@nixos.org) if you'd like to help!
+Main organisers: @ners, @john-rodewald, @Lassulus, @Ra33it0
 
 ## Sponsorship tiers
 
 This should be displayed on the website.
 
-### Non-sponsorship donation (0+ EUR)
-- Supporting the conference and official Nix projects
-- Confirmation of donation via OpenCollective
-
-### Bronze (1024+ EUR):
+### Bronze (1024 EUR):
 - Linked logo on the website
-- Linked shout-out or repost from official social media accounts
-- Possibility to distribute your own stickers/swag/merch at the venue
-- Tickets: 1+ corporate tickets[^1]
+- Tickets: 1 corporate tickets
 
-[^1]: One corporate ticket per 1024 EUR.
-  Only corporate tickets come with company name/logo recognition on the badge.
-  Corporate tickets can also be bought individually when ticket sales open.
-
-### Silver (2048+ EUR)
+### Silver (4096 EUR)
 - Everything from Bronze
 - Shout-out in the opening
-- Slot on break slideshow (provide a slide in advance)
-- Possibility to distribute flyers (provide them in advance) to all attendees in bag
-- Tickets: 2+ corporate tickets[^1]
+- Tickets: 2 corporate tickets
 
-### Gold (4096+ EUR):
+### Gold (8192 EUR):
 - Everything from Silver
 - 5 minute lightning talk slot
 - Dedicated space for a booth[^2]
-- Tickets: 4+ corporate tickets[^1]
+- Tickets: 4 corporate tickets
 
 [^2]: These perks may be limited in availability.
 
-### Diamond (8192+ EUR):
+### Diamond (16384 EUR):
 - Everything from Gold
 - Logo on some official conference swag[^2][^3]
-- 1 minute presentation slot (provide the slides in advance) in the conference opening
-- Intro of all recordings show your name/logo
 - Possibility to distribute items (provide them in advance) to all attendees in bag
-- Tickets: 8+ corporate tickets[^1]
+- Tickets: 8 corporate tickets
 
 [^3]: These perks require production and cannot be guaranteed if too late.
 
 ### General info
 - Sponsors can be tier-limited or rejected by the Nix Steering Committee for any reason.
-- The outline of all sponsor content must be disclosed in advance.
+- The outline of sponsor content may be requested to be disclosed in advance.
   We reserve the right to reject content.
 - Visibility priority is given according to tiers and donation amount.
 - The sponsor can selectively abstain from perks.
@@ -72,7 +59,7 @@ This should be displayed on the website.
 
 ### How to sponsor
 
-Send an email to sponsor@nixos.org (which will forward to both the Nix Steering Committee and the NixOS Foundation board) with:
+Send an email to board@nixos.org with:
 - Company name and website
 - Desired tier, amount and perks
 - Any other details
@@ -80,15 +67,11 @@ Send an email to sponsor@nixos.org (which will forward to both the Nix Steering 
 ## Sponsorship process
 
 The following is internal documentation and should not go on the website.
-For 2025 it involves the following respondents:
-- Board respondent: @ra33it0 (deputy: @infinisil)
-- SC respondent: @tomberek (deputy: @winterqt)
 
-1. After receiving the email, board respondent replies that the email was received and that they will hear back within about 2 weeks.
-2. SC respondent ensures the SC internally rejects or provisionally approves the sponsor within 1 week.
-   - If rejected, SC respondent replies to the sponsor with the rejection message.
-3. If provisionally approved by the SC, SC respondent forwards the name and website of the sponsor to the NixCon organisers, who have 2 days to issue objections.
-4. Within 1 week, the SC respondent checks whether organisers have issued objections, and if so, ensures that the SC internally reevaluates final rejection or approval of the sponsor.
-   - If rejected, SC respondent replies to the sponsor with the rejection message.
-5. If accepted, SC informs the board respondent and the organisers of the sponsor being accepted.
-6. Board respondent sends follow-up instructions to the sponsor and tracks the status of payment and perk delivery.
+In order to facilitate sponsorships, the board, the SC and the NixCon organisers should be in a private channel.
+
+1. When receiving a sponsor request, the board replies with a confirmation and forwards the request to the private channel
+2. The organisers and SC can discuss the request, with the SC making the call to approve or reject (majority vote)
+   - If rejected, the board will let the sponsor know
+3. If accepted, the board sends follow-up instructions to the sponsor
+4. Once the sponsor payment is confirmed, the board connects the sponsor to the organisers for perk delivery


### PR DESCRIPTION
> [!Note]
> Alternative to https://github.com/NixOS/org/pull/251
>  This version does _not_ allow volunteers with responsibilities to discuss sponsors before they're approved/rejected

It's not ideal how the [2026 sponsorship tiers](https://2026.nixcon.org/#sponsors) were changed without updating the document here. I'm also not sure how the changes were decided, but I don't think they need SC/board approval, so fine by me :)

The more important change here is a simplified sponsorship approval process with much lower bureaucracy compared to last years.

@NixOS/steering Please majority approve
@ners @john-rodewald @Lassulus @Ra33it0 Please approve