### PR TITLE
ruleset/nixpkgs: enable merge queue for staging-26.05, staging-next-26.05

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
+++ b/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
@@ -14,7 +14,9 @@
         "refs/heads/staging-next",
         "refs/heads/staging-nixos",
         "refs/heads/staging-next-25.11",
-        "refs/heads/staging-25.11"
+        "refs/heads/staging-25.11",
+        "refs/heads/staging-next-26.05",
+        "refs/heads/staging-26.05"
       ]
     }
   },


### PR DESCRIPTION
Part of the branch-off process for the 26.05 release.