### PR TITLE
rulesets/nixpkgs: re‐export

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
+++ b/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
@@ -14,11 +14,11 @@
         "refs/heads/staging-next",
         "refs/heads/staging-nixos",
         "refs/heads/staging-next-25.11",
-        "refs/heads/staging-nixos-25.11",
         "refs/heads/staging-25.11",
         "refs/heads/staging-next-26.05",
-        "refs/heads/staging-nixos-26.05",
-        "refs/heads/staging-26.05"
+        "refs/heads/staging-26.05",
+        "refs/heads/staging-nixos-25.11",
+        "refs/heads/staging-nixos-26.05"
       ]
     }
   },


### PR DESCRIPTION
Trivial change, but apparently the ordering here is preserved… (and it seems that applying changes via re‐import doesn’t work unless you also delete the previous ruleset first).