### PR TITLE
Update sponsorship tiers

### DIFF
--- a/doc/nixcon.md
+++ b/doc/nixcon.md
@@ -55,7 +55,10 @@ This should be displayed on the website.
 - Visibility priority is given according to tiers and donation amount.
 - The sponsor can selectively abstain from perks.
 - Surplus funds will be used to support official Nix projects.
-- Reach out if you'd like to sponsor in a more custom way, such as food, drinks, services, equipment, or only specific perks.
+- Reach out if you'd like to sponsor in a non-monetary way, such as food, drinks, services, equipment.
+- Only the exact tiers are allowed, perks can not be negotiated.
+- Core perks (including physical booth space) may not be pooled, split, or shared between multiple independent corporate entities.
+- Sponsors must be treated equally according to the established prospectus.
 
 ### How to sponsor
 


### PR DESCRIPTION
This was already approved by SC and board.
- First part: https://github.com/NixOS/steering-committee/pull/28
- Second part was to
  > Disallow negotiations of perks, only the exact tiers are allowed, custom non-monetary sponsorships are still allowed

  which was voted with from @philiptaron, @K900 (for this year), @roberth, @Ericson2314 and @tomberek, abstain from @JulienMalka and @cafkafk absent.

  No reasons were agreed upon by the entire SC, but the following points were brought up during discussion:
  - Custom tiers/perks was not advertised on the website this year
  - Adding it now would be unfair to the sponsors who already committed
  - Even if we reach out to existing sponsors, it would be difficult to reevaluate a sponsorship in corporate settings
  - If a sponsor wants a perk, they need to pay for the tier it's in, be more hard-nosed about them being more expensive this year

  The board has voted 5/5 to agree to the policy to be in alignment with SC, but desire a more organiser-empowering policy for next year.