### PR TITLE
Make home-manager official

### DIFF
--- a/doc/github.md
+++ b/doc/github.md
@@ -22,6 +22,12 @@ They can however make use of the [Nixpkgs merge bot](https://github.com/NixOS/ni
 
 The [Nixpkgs core team](./nixpkgs-core.md) controls this repository.
 
+### [home-manager](https://github.com/NixOS/home-manager)
+
+The user environment manager.
+
+It is administered by @khaneliman and @rycee.
+
 ### [nix](https://github.com/NixOS/nix)
 
 The Nix language and CLI implementation.


### PR DESCRIPTION
As was approved by the @NixOS/steering, as well as the home-manager owners, see https://github.com/NixOS/steering-committee/pull/30 :tada: 

Preparation checklist for repo transfer:
- [x] GitHub transfer
  - [x] Prepare: Ensure pages fallback redirects exist using a method like [here](https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7). I've prepared this so that nix-community admins can just [click here](https://github.com/new?template_name=nix-community.github.io&template_owner=nixos-test-org) to create the https://github.com/nix-community/nix-community.github.io repo from https://github.com/nixos-test-org/nix-community.github.io as a template. Once deployed, https://nix-community.github.io/ should not be 404 anymore.
    - I tested this to the most part, but if it's important to have as little downtime of home-manager urls as possible, give @infinisil temporary access to the repo so I can fix things right away if there's a problem.
  - [ ] Prepare (some admin of the home-manager repo (@khaneliman or @rycee are listed as maintainers at least)): Add @infinisil (an [org owner](https://github.com/NixOS/org/blob/main/doc/github-org-owners.md)) as an admin to the home-manager repo
  - [ ] Afterwards: Enable Pages, trigger deploy, check that https://nixos.github.io/home-manager works, as well as links like [this](https://nix-community.github.io/home-manager/nix-darwin-options.xhtml#nix-darwin-opt-home-manager.backupFileExtension)
- [ ] Cachix
  - [ ] Prepare: Create a new cachix for home-manager
  - [ ] Prepare: PR to switch cachix in .github/workflows
  - [ ] Afterwards: Set secret: CACHIX_AUTH_TOKEN
  - [ ] Afterwards: Merge the PR
- [ ] workflows
  - [ ] Prepare: PR to enable CI for nixos org in .github/workflows
  - [ ] Afterwards: Merge it
- [ ] Home-manager CI App
  - [ ] Prepare: Make @infinisil (or another org owner) owner of the Home-manager CI app
  - [ ] Afterwards: [Transfer the App](https://docs.github.com/en/apps/maintaining-github-apps/transferring-ownership-of-a-github-app)
  - [ ] Afterwards: Set secret CI_APP_PRIVATE_KEY
  - [ ] Afterwards: Set var CI_APP_ID
- [ ] Buildbot
  - [ ] In advance: Add NixOS/home-manager to allow-list: https://github.com/nix-community/infra/blob/master/modules/nixos/buildbot.nix
  - [ ] In advance: Make App public
  - [ ] Afterwards: Install App on the NixOS org, giving access to home-manager repo
- [ ] RFC39
  - [ ] In advance: Create @NixOS/home-manager-maintainers
  - [ ] In advance: Populate it automatically by integrating https://github.com/NixOS/infra/blob/main/modules/rfc39.nix and https://github.com/nix-community/infra/blob/7dc0562fbd33d8ffa56f8fb88d8683be46c4239c/modules/nixos/rfc39.bash#L20 into https://github.com/nix-community/infra/blob/master/modules/nixos/rfc39.nix

I believe once all advance tasks are done, I should be able to do the migration.

Other transfer tasks:
- [ ] Remove home-manager from .github/workflows
- [ ] Replace nix-community -> nixos treewide
- [ ] Transfer Weblate project
- [ ] Transfer Matrix rooms
- [ ] Transfer buildbot