### PR TITLE
rulesets/nixpkgs: Remove 25.11 rules

### DIFF
--- a/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
+++ b/rulesets/nixpkgs/require-merge-queue-except-periodic-merges.json
@@ -13,11 +13,8 @@
         "refs/heads/staging",
         "refs/heads/staging-next",
         "refs/heads/staging-nixos",
-        "refs/heads/staging-next-25.11",
-        "refs/heads/staging-25.11",
         "refs/heads/staging-next-26.05",
         "refs/heads/staging-26.05",
-        "refs/heads/staging-nixos-25.11",
         "refs/heads/staging-nixos-26.05"
       ]
     }

--- a/rulesets/nixpkgs/require-merge-queue.json
+++ b/rulesets/nixpkgs/require-merge-queue.json
@@ -10,7 +10,6 @@
       "exclude": [],
       "include": [
         "~DEFAULT_BRANCH",
-        "refs/heads/release-25.11",
         "refs/heads/release-26.05"
       ]
     }


### PR DESCRIPTION
NixOS 25.11 is end-of-life. Part of my [EOL cleanup checklist](https://nixos.github.io/release-wiki/EOL-Cleanup.html).