### PR TITLE
Add a link to the flying circus status page

### DIFF
--- a/doc/discourse.md
+++ b/doc/discourse.md
@@ -2,7 +2,7 @@
 
 The [NixOS Discourse instance](https://discourse.nixos.org/) is one of the primary communication platforms for the Nix community.
 
-That subdomain is hosted by [Flying Circus](https://flyingcircus.io/)
+That subdomain is hosted by [Flying Circus](https://flyingcircus.io/). If you're seeing issues, first check <https://status.flyingcircus.io/>.
 
 To request permissions or changes to Discourse, talk to one of the [administrators](https://discourse.nixos.org/about).
 


### PR DESCRIPTION
Suggested by @ctheune in matrix.