### PR TITLE
discourse: remove jtojnar as admin

### DIFF
--- a/doc/discourse.md
+++ b/doc/discourse.md
@@ -12,7 +12,7 @@ Moderators:
 - @lassulus
 
 SC representatives:
-- @jtojnar
+- vacant
 
 Flying Circus Administrators:
 - @ctheune


### PR DESCRIPTION
Jan does not represent the SC any more.