### PR TITLE
CODEOWNERS: Remove jtojnar from discourse

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /rulesets @NixOS/org
 
 /doc/org-repo.md @NixOS/steering
-/doc/discourse.md @NixOS/steering @mweinelt @lassulus @jtojnar @ctheune @dpausp
+/doc/discourse.md @NixOS/steering @mweinelt @lassulus @ctheune @dpausp
 /doc/github.md @NixOS/org
 /doc/github-org-owners.md @NixOS/steering
 /doc/matrix.md @NixOS/steering


### PR DESCRIPTION
Follow up to https://github.com/NixOS/org/commit/94295750f68d61f06b038ab918f578e86782c255